### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "chroma-externals"]
 	path = chroma-externals
-	url = ../chroma-externals
+	url = ssh://review.whamcloud.com:29418/chroma-externals


### PR DESCRIPTION
The /chroma-externals submodule is pointing to a relative location which is incorrect
now that we are on GitHub.

Fix it to point to the existing location.