### PR TITLE
HYD-7331 DRY out end of test and abort handling

### DIFF
--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
@@ -2,6 +2,7 @@
 
 . chroma-manager/tests/framework/utils/defaults.sh
 . chroma-manager/tests/framework/utils/selective_auto_pass.sh
+. chroma-manager/tests/framework/utils/cleanup.sh
 
 set_defaults false
 check_for_autopass
@@ -15,13 +16,16 @@ echo "+ curl -f -k -O -u $JENKINS_USER:********* \"$JOB_URL/$ARCHIVE_NAME\""
 curl -f -k -O -u $JENKINS_USER:$JENKINS_PULL "$JOB_URL/$ARCHIVE_NAME"
 set -x
 
-# Release the provisioned cluster (at exit of this script)
-trap "set +e
-set -x
-# Gather logs from nodes
-python $CHROMA_DIR/chroma-manager/tests/integration/utils/chroma_log_collector.py $WORKSPACE/test_logs $CLUSTER_CONFIG
+got_aborted=false
+# Gather logs from nodes and release the cluster at exit
 
-$CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster" EXIT
+trap "set +e; cleanup" EXIT
+
+trap "set -x
+got_aborted=true
+echo \"Got SIGTERM\"
+ps axf
+exit 1" TERM
 
 $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
 

--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/run_tests
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/run_tests
@@ -17,8 +17,7 @@ eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CO
 MEASURE_COVERAGE=${MEASURE_COVERAGE:-true}
 TESTS=${TESTS:-"tests/integration/existing_filesystem_configuration/"}
 
-trap "set +e
-collect_reports" EXIT
+trap "set +e; collect_reports; cleanup" EXIT
 
 echo "Begin running tests..."
 

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
@@ -2,6 +2,7 @@
 
 . chroma-manager/tests/framework/utils/defaults.sh
 . chroma-manager/tests/framework/utils/selective_auto_pass.sh
+. chroma-manager/tests/framework/utils/cleanup.sh
 
 set_defaults false
 check_for_autopass
@@ -14,55 +15,9 @@ echo "+ curl -f -k -O -u $JENKINS_USER:********** \"$JOB_URL/$ARCHIVE_NAME\""
 curl -f -k -O -u $JENKINS_USER:$JENKINS_PULL "$JOB_URL/$ARCHIVE_NAME"
 set -x
 
-# Gather logs from nodes and release the cluster at exit
-cleanup() {
-    set -x
-    set +e
-    if $got_aborted; then
-        tmpfile=/tmp/abort.$$.debug
-        exec 2>$tmpfile
-        env >&2
-    fi
-    python $CHROMA_DIR/chroma-manager/tests/integration/utils/chroma_log_collector.py $WORKSPACE/test_logs $CLUSTER_CONFIG | tee $WORKSPACE/log_collector_out 2>&1 || true
-    # look for known failures in the logs
-    if grep "LDISKFS-fs (.*): group descriptors corrupted" $WORKSPACE/test_logs/*-messages.log; then
-        echo "bug: TEI-39" test_output
-    fi
-    if egrep "^ssh: Could not resolve hostname lotus-[0-9][0-9]*vm1*4\.iml\.intel\.com: Name or service not known" $WORKSPACE/log_collector_out; then
-        echo "bug: TEI-1327"
-    fi
-    rm -f $WORKSPACE/log_collector_out
-    if grep "AssertionError: 300 not less than 300 : Timed out waiting for host to come back online" $WORKSPACE/test_logs/*-chroma_test.log; then
-        echo "bug: HYD-2889"
-    fi
-    if grep "Could not match packages: Cannot retrieve repository metadata (repomd.xml) for repository: lustre-client. Please verify its path and try again" $WORKSPACE/test_logs/*-chroma_test.log; then
-        echo "bug: HYD-2948"
-    fi
-
-    if [ -f $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster ]; then
-        $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster || true
-    else
-        {
-        echo "*****************************************************************"
-        echo "$CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster could not be found"
-        if $got_aborted; then
-            echo "this job was aborted!!"
-        fi
-        pwd
-        ls -l chroma
-        echo "*****************************************************************"
-        } >&2
-    fi
-
-    echo "exit trap done" >&2
-    if [ -n "$tmpfile" -a -e "$tmpfile" ]; then
-        cat $tmpfile | mail -s "job aborted" brian.murrell@intel.com
-        #rm $tmpfile
-    fi
-}
-
 got_aborted=false
-trap cleanup EXIT
+# Gather logs from nodes and release the cluster at exit
+trap "set +e; cleanup" EXIT
 
 trap "set -x
 got_aborted=true

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/run_tests
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/run_tests
@@ -16,8 +16,7 @@ eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CO
 TESTS=${TESTS:-"tests/integration/shared_storage_configuration/"}
 MEASURE_COVERAGE=${MEASURE_COVERAGE:-true}
 
-trap "set +e
-collect_reports" EXIT
+trap "set +e; collect_reports; cleanup" EXIT
 
 echo "Begin running tests..."
 

--- a/chroma-manager/tests/framework/utils/cleanup.sh
+++ b/chroma-manager/tests/framework/utils/cleanup.sh
@@ -1,0 +1,45 @@
+cleanup() {
+    set -x
+    set +e
+    if $got_aborted; then
+        tmpfile=/tmp/abort.$$.debug
+        exec 2>$tmpfile
+        env >&2
+    fi
+    python $CHROMA_DIR/chroma-manager/tests/integration/utils/chroma_log_collector.py $WORKSPACE/test_logs $CLUSTER_CONFIG | tee $WORKSPACE/log_collector_out 2>&1 || true
+    # look for known failures in the logs
+    if grep "LDISKFS-fs (.*): group descriptors corrupted" $WORKSPACE/test_logs/*-messages.log; then
+        echo "bug: TEI-39" test_output
+    fi
+    if egrep "^ssh: Could not resolve hostname lotus-[0-9][0-9]*vm1*4\.iml\.intel\.com: Name or service not known" $WORKSPACE/log_collector_out; then
+        echo "bug: TEI-1327"
+    fi
+    rm -f $WORKSPACE/log_collector_out
+    if grep "AssertionError: 300 not less than 300 : Timed out waiting for host to come back online" $WORKSPACE/test_logs/*-chroma_test.log; then
+        echo "bug: HYD-2889"
+    fi
+    if grep "Could not match packages: Cannot retrieve repository metadata (repomd.xml) for repository: lustre-client. Please verify its path and try again" $WORKSPACE/test_logs/*-chroma_test.log; then
+        echo "bug: HYD-2948"
+    fi
+
+    if [ -f $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster ]; then
+        $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster || true
+    else
+        {
+        echo "*****************************************************************"
+        echo "$CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/release_cluster could not be found"
+        if $got_aborted; then
+            echo "this job was aborted!!"
+        fi
+        pwd
+        ls -l $CHROMA_DIR
+        echo "*****************************************************************"
+        } >&2
+    fi
+
+    echo "exit trap done" >&2
+    if [ -n "$tmpfile" -a -e "$tmpfile" ]; then
+        cat $tmpfile | mail -s "job aborted" brian.murrell@intel.com
+        #rm $tmpfile
+    fi
+}


### PR DESCRIPTION
There is an opportunity to DRY out the code that handles the end-of-test
processing and abort handling in the SSI and EFS tests.

This patch does that by moving some common code to a single function as
well as adding abort handling to the EFS test.