### PR TITLE
Create docs dir for github pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+# Intel Manager for Lustre


### PR DESCRIPTION
Fixes #8.

Create a docs dir for usage with github pages.

Signed-off-by: Joe Grund <grundjoseph@gmail.com>