### PR TITLE
json_cfg2sh.py does not include worker nodes in ALL_NODES

### DIFF
--- a/chroma-manager/tests/utils/json_cfg2sh.py
+++ b/chroma-manager/tests/utils/json_cfg2sh.py
@@ -7,14 +7,14 @@ f.close()
 
 servers = []
 workers = []
+all_nodes = []
 for server in config["lustre_servers"]:
     if server.get("profile") and \
        server["profile"] == "posix_copytool_worker":
         workers.append(server["address"])
     else:
         servers.append(server["address"])
-
-all_nodes = servers[:]
+    all_nodes.append(server["address"])
 
 if len(config['chroma_managers']) > 0:
     chroma_manager = config['chroma_managers'][0]


### PR DESCRIPTION
Fixes #10 

When enumerating ALL_NODES, json_cfg2sh.py is not including worker
nodes in that list.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Change-Id: I6e75356f2abbd344d8fa3cf877245fdb6fff66b0