### PR TITLE
Support multiple parallel unit-tests runs

### DIFF
--- a/chroma-manager/tests/framework/unit/jenkins_steps/main
+++ b/chroma-manager/tests/framework/unit/jenkins_steps/main
@@ -7,15 +7,17 @@ set_defaults false
 check_for_autopass
 
 # figure out which parallel invocation we might be
-WORKSPACE_NUMBER=${WORKSPACE/$HOME\/unit-tests@/}
+WORKSPACE_NUMBER=${WORKSPACE/$HOME\/workspace\/unit-tests@/}
 WORKSPACE_NUMBER=${WORKSPACE_NUMBER%%/*}
 
-# use the database created for the workspace number
-ed <<EOF $CHROMA_DIR/chroma-manager/settings.py
+if [ -n "$WORKSPACE_NUMBER" ]; then
+    # use the database created for the workspace number
+    ed <<EOF $CHROMA_DIR/chroma-manager/settings.py
 /'NAME': 'chroma'/s/',/$WORKSPACE_NUMBER',/
 w
 q
 EOF
+fi
 
 # Get the chroma-externals repo as pip is going to need it
 scripts/update_chroma-externals.py

--- a/chroma-manager/tests/framework/unit/jenkins_steps/main
+++ b/chroma-manager/tests/framework/unit/jenkins_steps/main
@@ -6,13 +6,24 @@
 set_defaults false
 check_for_autopass
 
+# figure out which parallel invocation we might be
+WORKSPACE_NUMBER=${WORKSPACE/$HOME\/unit-tests@/}
+WORKSPACE_NUMBER=${WORKSPACE_NUMBER%%/*}
+
+# use the database created for the workspace number
+ed <<EOF $CHROMA_DIR/chroma-manager/settings.py
+/'NAME': 'chroma'/s/',/$WORKSPACE_NUMBER',/
+w
+q
+EOF
+
 # Get the chroma-externals repo as pip is going to need it
 scripts/update_chroma-externals.py
 
 # Pip install requirements
 cd $CHROMA_DIR/chroma-manager
 make requirements
-python tests/utils/pip_install_requirements.py $(pwd)/../chroma-externals
+python tests/utils/pip_install_requirements.py $PWD/../chroma-externals
 
 #
 # patch behave for https://github.com/behave/behave/issues/63 with https://github.com/jenisys/behave/commit/6fa47d414bf25a53121edeb7caebac4d9d1b5fb4.diff


### PR DESCRIPTION
Each invocation requires it's own database, so leverage the serial
identifier of the Jenkins workspace to point MFL at it's own data-
base.