### PR TITLE
SSHException: Error reading SSH protocol banner debug

### DIFF
--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -402,6 +402,8 @@ class RealRemoteOperations(RemoteOperations):
                           print_result(ping_gw_result),
                           ping_result2_report))
 
+            return Shell.RunResult(1, "", "", timeout=False)
+
         transport = ssh.get_transport()
         transport.set_keepalive(20)
         channel = transport.open_session()

--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -383,7 +383,6 @@ class RealRemoteOperations(RemoteOperations):
             ping_result1 = Shell.run(['ping', '-c', '1', '-W', '1', address])
             ifconfig_result = Shell.run(['ifconfig', '-a'])
             ip_route_ls_result = Shell.run(['ip', 'route', 'ls'])
-            ip_route_ls_result = Shell.run(['ip', 'route', 'ls'])
             try:
                 gw = [l for l in ip_route_ls_result.stdout.split('\n') \
                       if l.startswith("default ")][0].split()[2]


### PR DESCRIPTION
Every now and then an ssh operation in one of our tests throws an
exception such as:

Traceback (most recent call last):
  File "/usr/share/chroma-manager/tests/integration/shared_storage_configuration/test_lnet_functionality.py", line 15, in setUp
    super(TestLNetFunctionality, self).setUp()
  File "/usr/share/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py", line 137, in setUp
    self.reset_cluster()
  File "/usr/share/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py", line 626, in reset_cluster
    self.remote_operations.unmount_clients()
  File "/usr/share/chroma-manager/tests/integration/core/remote_operations.py", line 921, in unmount_clients
    'mount')
  File "/usr/share/chroma-manager/tests/integration/core/remote_operations.py", line 375, in _ssh_address
    ssh.connect(address, **args)
  File "/usr/lib/python2.7/site-packages/paramiko/client.py", line 338, in connect
    t.start_client()
  File "/usr/lib/python2.7/site-packages/paramiko/transport.py", line 492, in start_client
    raise e
SSHException: Error reading SSH protocol banner

It would be good to get some idea of why this is happening.

So gather some diagnostics at the time that this is occurring.  We
might discover that simply trying again will be successful but it
would be interesing to see current state before simply assuming
that is the solution.