### PR TITLE
HYD-6908 Remove unnecessary fetchhelp's

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -140,9 +140,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                 self.wait_until_true(self.api_contactable)
                 self.remote_operations.unmount_clients()
                 self.api_force_clear()
-                self._fetch_help(lambda: self.remote_operations.clear_ha(self.TEST_SERVERS),
-                                 ['chris.gearing@intel.com'],
-                                 'soft clear ha failure')
+                self.remote_operations.clear_ha(self.TEST_SERVERS)
                 self.remote_operations.clear_lnet_config(self.TEST_SERVERS)
 
             if config.get('managed'):
@@ -195,9 +193,6 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                                                                   "==== stopping test %s =====" % self)
 
                 if len(down_nodes) and (self.down_node_expected is False):
-                    self._fetch_help(lambda: 1 / 0,
-                                     ['chris.gearing@intel.com'],
-                                     "After test, some servers were no longer running: %s" % ", ".join(down_nodes))
                     logger.warning("After test, some servers were no longer running: %s" % ", ".join(down_nodes))
                     raise RuntimeError("AWOL servers after test: %s" % ", ".join(down_nodes))
 
@@ -294,11 +289,6 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                             print step['console']
                             print step['backtrace']
                             print ''
-
-                            if 'Unable to update any nodes' in step['console']:
-                                self._fetch_help(lambda: 1 / 0,
-                                                 ['chris.gearing@intel.com'],
-                                                 'Unable to update any nodes: %s' % step['description'])
             elif disposition == "TIMED OUT":
                 if job['state'] != "complete":
                     print "Job %s incomplete:" % job['id']
@@ -627,7 +617,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         self.reset_chroma_manager_db()
         self.remote_operations.stop_agents(s['address'] for s in config['lustre_servers'])
         if config.get('managed'):
-            self.remote_operations.clear_ha(config['lustre_servers'])
+            self.remote_operations.clear_ha(self.TEST_SERVERS)
             self.remote_operations.clear_lnet_config(self.TEST_SERVERS)
 
     def reset_chroma_manager_db(self):

--- a/chroma-manager/tests/integration/core/failover_testcase_mixin.py
+++ b/chroma-manager/tests/integration/core/failover_testcase_mixin.py
@@ -76,9 +76,7 @@ class FailoverTestCaseMixin(ChromaIntegrationTestCase):
             command = response.json
             failover_target_command_ids.append(command['id'])
 
-        self._fetch_help(lambda: self.wait_for_commands(self.chroma_manager, failover_target_command_ids),
-                         ['chris.gearing@intel.com'],
-                         'failed to failover')
+        self.wait_for_commands(self.chroma_manager, failover_target_command_ids)
 
         # Wait for failover to occur
         self.wait_until_true(lambda: self.targets_for_volumes_started_on_expected_hosts(filesystem_id, volumes_expected_hosts_in_failover_state))

--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -891,10 +891,9 @@ class RealRemoteOperations(RemoteOperations):
                                            "hostname",
                                            expected_return_code=None).rc == 0
 
-            self._test_case._fetch_help(lambda: self._test_case.assertTrue(False,
-                                                                           "Timed out waiting for host %s to come back online.\n"
-                                                                           "Host is actually alive %s" % (hostname, host_alive)),
-                                        ['chris.gearing@intel.com'])
+            self._test_case.assertTrue(False,
+                                       "Timed out waiting for host %s to come back online.\n"
+                                       "Host is actually alive %s" % (hostname, host_alive))
 
         if monitor_server:
             result = self._ssh_address(

--- a/chroma-manager/tests/integration/core/utility_testcase.py
+++ b/chroma-manager/tests/integration/core/utility_testcase.py
@@ -195,12 +195,12 @@ class UtilityTestCase(TestCase):
 
         Typical usage.
         self._fetch_help(lambda: self.assertEqual(commandResult, True),
-                         ['chris.gearing@intel.com'],
+                         ['joe.grund@intel.com', 'tom.nabarro@intel.com', 'william.c.johnson@intel.com'],
                          'Send the cavalry',
                          callback=lambda: check_if_significant(data))
 
         self._fetch_help(lambda: self.assertEqual(commandResult, True),
-                         ['chris.gearing@intel.com'],
+                         ['joe.grund@intel.com', 'tom.nabarro@intel.com', 'william.c.johnson@intel.com'],
                          lambda: 'Send the cavalry',
                          callback=lambda: check_if_significant(data))
 


### PR DESCRIPTION
Chris Gearing has tended to not remove fetchhelps (through laziness) when
landing code. This means I get messages for failures that are really just
test failures and not related to the message. He has added them to a junk
mail filter!

But when this happens tests take additional time.

To fix this double whammy burger I've removed the fetch helps for
chris.gearing@intel.com and left just the one for HYD-4050 which goes to
Brian.

  - Remove 5 fetchelp usages
  - Change usage documentation to include names of current developers

Change-Id: I600ce5cde71dd27fa2c007d7266a3df3ceb988bd
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>