### PR TITLE
Fix bugs in simulator corosync configuration due to race conditions

### DIFF
--- a/chroma-manager/chroma_core/models/corosync2.py
+++ b/chroma-manager/chroma_core/models/corosync2.py
@@ -2,7 +2,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2016 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its

--- a/chroma-manager/chroma_core/models/corosync2.py
+++ b/chroma-manager/chroma_core/models/corosync2.py
@@ -139,13 +139,7 @@ class AutoConfigureCorosyncStep(Step):
                                                     string.digits) for _ in range(cls._pcs_password_length))
 
     def run(self, kwargs):
-        from chroma_core.models import ManagedHost
-
-        # update objects
-        host = ManagedHost.objects.get(fqdn=kwargs['corosync_configuration'].host.fqdn)
-        corosync_configuration = host.corosync_configuration
-
-        assert host.state == 'packages_installed', 'packages have to be installed before corosync can be configured'
+        corosync_configuration = kwargs['corosync_configuration']
 
         # detect local interfaces for use in corosync 'rings', network level configuration only
         config = self.invoke_agent_expect_result(corosync_configuration.host, "get_corosync_autoconfig")
@@ -169,6 +163,8 @@ class AutoConfigureCorosyncStep(Step):
         # Serialize across nodes with the same mcast_port so that we ensure commands
         # are executed in the same order.
         with peer_mcast_ports_configuration_lock[config['mcast_port']]:
+            from chroma_core.models import ManagedHost
+
             corosync_peers = self._corosync_peers(corosync_configuration.host.fqdn, config['mcast_port'])
 
             logging.debug("Node %s has corosync peers %s" % (corosync_configuration.host.fqdn,

--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -280,14 +280,14 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
             job_steps = [self.get_json_by_uri(s) for s in job['steps']]
             if disposition == "FAILED":
                 if job['errored']:
-                    print "Job %s Errored:" % job['id']
+                    print "Job %s Errored (%s):" % (job['id'], job['description'])
                     print job
                     print ''
                     for step in job_steps:
                         if step['state'] == 'failed':
-                            print "Step %s (%s) failed:" % (step['id'], step['description'])
-                            print step['console']
-                            print step['backtrace']
+                            print "Step %s failed:" % step['id']
+                            for k, v in step.iteritems():
+                                print "%s: %s" % (k, v)
                             print ''
             elif disposition == "TIMED OUT":
                 if job['state'] != "complete":

--- a/chroma-manager/tests/unit/chroma_core/jobs/test_corosync2_jobs.py
+++ b/chroma-manager/tests/unit/chroma_core/jobs/test_corosync2_jobs.py
@@ -13,9 +13,11 @@ class TestCorosyncConfiguration(TestJobs):
 
         mock_corosync_configuration = mock.MagicMock()
         mock_corosync_configuration.host.fqdn = 'bob.monkhouse.show'
+        mock_corosync_configuration.host.state = 'packages_installed'
 
         mock_actioning_host = mock.MagicMock()
         mock_actioning_host.fqdn = 'bruce.forsyth.show'
+        mock_actioning_host.state = 'packages_installed'
 
         mock.patch('chroma_core.models.AutoConfigureCorosyncStep._corosync_peers', return_value=[mock_actioning_host.fqdn]).start()
 

--- a/cluster-sim/cluster_sim/fake_server.py
+++ b/cluster-sim/cluster_sim/fake_server.py
@@ -38,7 +38,7 @@ from cluster_sim import utils
 from chroma_agent.device_plugins.action_runner import CallbackAfterResponse
 from cluster_sim.fake_action_plugins import FakeActionPlugins
 from cluster_sim.fake_device_plugins import FakeDevicePlugins
-from chroma_agent.chroma_common.lib.agent_rpc import agent_result, agent_result_ok, agent_error
+from chroma_agent.chroma_common.lib.agent_rpc import agent_result, agent_result_ok
 from chroma_agent.chroma_common.lib.date_time import IMLDateTime
 
 # Simulated duration, in seconds, from the time a server shutdown is issued
@@ -91,6 +91,7 @@ class FakeServer(utils.Persisted):
         'lnet_up': False,
         'stats': None,
         'packages': {},
+        'client_mounts': {},
         'corosync': CorosyncState('stopped', 3000),
         'pacemaker': PacemakerState('stopped')
     }

--- a/cluster-sim/cluster_sim/fake_server.py
+++ b/cluster-sim/cluster_sim/fake_server.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2016 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -38,17 +38,17 @@ from cluster_sim import utils
 from chroma_agent.device_plugins.action_runner import CallbackAfterResponse
 from cluster_sim.fake_action_plugins import FakeActionPlugins
 from cluster_sim.fake_device_plugins import FakeDevicePlugins
-from chroma_agent.chroma_common.lib.agent_rpc import agent_result, agent_result_ok
+from chroma_agent.chroma_common.lib.agent_rpc import agent_result, agent_result_ok, agent_error
 from chroma_agent.chroma_common.lib.date_time import IMLDateTime
 
 # Simulated duration, in seconds, from the time a server shutdown is issued
 # until it's stopped. When simulating a shutdown, it will always take at
 # least this long.
-MIN_SHUTDOWN_DURATION = 10
+MIN_SHUTDOWN_DURATION = 5  # 10
 # Simulated duration, in seconds, from the time a server is started until
 # it's running. When simulating a startup, it will always take at least
 # this long.
-MIN_STARTUP_DURATION = 20
+MIN_STARTUP_DURATION = 5  # 20
 
 
 class PacemakerState(utils.DictStruct):

--- a/cluster-sim/cluster_sim/simulator.py
+++ b/cluster-sim/cluster_sim/simulator.py
@@ -285,6 +285,10 @@ class ClusterSimulator(Persisted):
         for cluster in self.clusters.values():
             cluster.clear_resources()
 
+        for server in self.servers.values():
+            server.reset_state()
+            server.save()
+
     def remove_server(self, fqdn):
         log.info("remove_server %s" % fqdn)
 

--- a/cluster-sim/cluster_sim/simulator.py
+++ b/cluster-sim/cluster_sim/simulator.py
@@ -286,7 +286,10 @@ class ClusterSimulator(Persisted):
             cluster.clear_resources()
 
         for server in self.servers.values():
-            server.reset_state()
+            # FIXME: we should completely clear state but apparently we're reliant on some of the keys between tests!
+            # server.reset_state()
+            server.stop_corosync()
+            server.stop_pacemaker()
             server.save()
 
     def remove_server(self, fqdn):

--- a/cluster-sim/cluster_sim/utils.py
+++ b/cluster-sim/cluster_sim/utils.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2015 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -88,14 +88,11 @@ class Persisted(object):
     filename = None
     default_state = {}
 
-    def _load_default(self):
-        self.state = deepcopy(self.default_state)
-
     def __init__(self, path):
         self.path = path
 
         if not self.path:
-            self._load_default()
+            self.reset_state()
         else:
             try:
                 self.state = json.load(open(os.path.join(self.path, self.filename), 'r'))
@@ -103,11 +100,11 @@ class Persisted(object):
                 # Now fixup and DictStruct's in the data
                 DictStruct.convert_dict(self.state)
             except IOError:
-                self._load_default()
+                self.reset_state()
 
     def save(self):
         if self.path:
-            json.dump(self.state, open(os.path.join(self.path, self.filename), 'w'), indent = 4)
+            json.dump(self.state, open(os.path.join(self.path, self.filename), 'w'), indent=4)
 
     def delete(self):
         if not self.path:
@@ -120,3 +117,6 @@ class Persisted(object):
                 pass
             else:
                 raise
+
+    def reset_state(self):
+        self.state = deepcopy(self.default_state)


### PR DESCRIPTION
Simulator tests failing due to https://jira.hpdd.intel.com/browse/HYD-7340

In order to remove the race condition

  - clear the simulator server data at the beginning of each test
  - don't return information from pacemaker/corosync when packages not installed

Change-Id: Iece96863aa1e2111cf355ac048c41a2255ef0529
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>