### PR TITLE
HYD-7321 Use lctl erase_lcfg to purge file systems

### DIFF
--- a/chroma-agent/tests/chroma_common/blockdevices/test_blockdevice_zfs.py
+++ b/chroma-agent/tests/chroma_common/blockdevices/test_blockdevice_zfs.py
@@ -230,19 +230,11 @@ kernel modules are functioning properly.
 
     def test_purge_filesystem_information(self):
         self.blockdevice = BlockDeviceZfs('zfs', self.dataset_path)
-        device_path = self.blockdevice._device_path
 
-        self.add_commands(CommandCaptureCommand(('zfs', 'canmount=on', device_path)),
-                          CommandCaptureCommand(('zfs', 'mount', device_path)),
-                          CommandCaptureCommand(('rm', 'testfs-a')),
-                          CommandCaptureCommand(('rm', 'testfs-b')),
-                          CommandCaptureCommand(('zfs', 'unmount', device_path)),
-                          CommandCaptureCommand(('zfs', 'canmount=off', device_path)))
+        self.add_commands(CommandCaptureCommand(('lctl', 'erase_lcfg', 'testfs')))
 
-        with mock.patch.object(glob, 'glob', return_value=['testfs-a', 'testfs-b']) as mock_glob:
+        with mock.patch.object(glob, 'glob', return_value=['testfs-a', 'testfs-b']):
             result = self.blockdevice.purge_filesystem_configuration('testfs', None)
-
-        mock_glob.assert_called_once_with('/%s/CONFIGS/%s-*' % (device_path, 'testfs'))
 
         self.assertEqual(result, None)
         self.assertRanAllCommandsInOrder()

--- a/chroma-common/blockdevices/blockdevice.py
+++ b/chroma-common/blockdevices/blockdevice.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2016 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -21,7 +21,7 @@
 
 
 from collections import namedtuple, defaultdict
-from ..lib import util
+from ..lib import util, shell
 import abc
 
 _cached_device_types = {}
@@ -152,7 +152,6 @@ class BlockDevice(object):
         """
         return None
 
-    @abc.abstractmethod
     def purge_filesystem_configuration(self, filesystem_name, log):
         """
         Purge the details of the filesystem from the mgs blockdevice.  This routine presumes that the blockdevice
@@ -162,4 +161,7 @@ class BlockDevice(object):
         :param log: The logger to use for log messages.
         :return: None on success or error message on failure
         """
-        pass
+        shell_result = shell.Shell.run(['lctl', 'erase_lcfg', filesystem_name])
+
+        if shell_result.rc != 0:
+            return "Purge filesystem failed to purge %s with error '%s'" % (filesystem_name, shell_result.stderr)

--- a/chroma-common/blockdevices/blockdevice_linux.py
+++ b/chroma-common/blockdevices/blockdevice_linux.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2016 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -269,39 +269,3 @@ class BlockDeviceLinux(BlockDevice):
             names = [name]
 
         return self.TargetsInfo(names, params)
-
-    def purge_filesystem_configuration(self, filesystem_name, log):
-        """
-         Purge the details of the filesystem from the mgs blockdevice.  This routine presumes that the blockdevice
-         is the mgs_blockdevice and does not make any checks
-
-         :param filesystem_name: The name of the filesystem to purge
-         :param log: The logger to use for log messages.
-         :return: None on success or error message
-         """
-        shell_result = shell.Shell.run(["debugfs", "-w", "-R", "ls -l CONFIGS/", self._device_path])
-
-        if shell_result.rc != 0:
-            return "Purge filesystem failed to interrogate ldiskfs device %s, error was %s" % \
-                   (self._device_path, shell_result.stderr)
-
-        victims = []
-        for line in shell_result.stdout.split("\n"):
-            try:
-                name = line.split()[8]
-            except IndexError:
-                continue
-
-            if name.startswith("%s-" % filesystem_name):
-                victims.append(name)
-
-        log.info("Purging config files: %s" % victims)
-
-        for victim in victims:
-            shell_result = shell.Shell.run(["debugfs", "-w", "-R", "rm CONFIGS/%s" % victim, self._device_path])
-
-            if shell_result.rc != 0:
-                return "Purge filesystem failed to purge %s from ldiskfs device %s, error was %s" % \
-                       (victim, self._device_path, shell_result.stderr)
-
-        return None

--- a/chroma-manager/chroma_core/models/filesystem.py
+++ b/chroma-manager/chroma_core/models/filesystem.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2016 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -22,9 +22,7 @@
 
 from django.db import models
 from chroma_core.lib.job import DependOn, DependAll, Step, job_log
-from chroma_core.models import ManagedTargetMount, ManagedMgs, FilesystemMember, ManagedTarget
-from chroma_core.models import UnmountStep
-from chroma_core.models import MountOrImportStep
+from chroma_core.models import ManagedMgs, FilesystemMember, ManagedTarget
 from chroma_core.models import NoNidsPresent
 from chroma_core.models import StatefulObject, StateChangeJob, StateLock, Job
 from chroma_core.models import DeletableDowncastableMetaclass, MeasuredEntity
@@ -198,11 +196,22 @@ class RemoveFilesystemJob(StateChangeJob):
             write = True))
         return locks
 
+    def get_deps(self):
+        deps = []
+
+        mgs_target = ObjectCache.get_one(ManagedTarget, lambda t: t.id == self.filesystem.mgs_id)
+
+        # Can't start a MGT that hasn't made it past formatting.
+        if mgs_target.state not in ['unformatted', 'formatted']:
+            deps.append(DependOn(mgs_target,
+                                 'mounted',
+                                 fix_state = 'unavailable'))
+        return DependAll(deps)
+
     def get_steps(self):
         steps = []
 
         mgs_target = ObjectCache.get_one(ManagedTarget, lambda t: t.id == self.filesystem.mgs_id)
-        mgs_primary_mount = ObjectCache.get_one(ManagedTargetMount, lambda mtm: mtm.target_id == mgs_target.id and mtm.primary is True)
 
         # Only try to purge filesystem from MGT if the MGT has made it past
         # being formatted (case where a filesystem was created but is being
@@ -214,27 +223,16 @@ class RemoveFilesystemJob(StateChangeJob):
         if self.filesystem.immutable_state:
             return steps
 
-        # Whether the MGS was officially up or not, try stopping it, idempotent so will succeed either way
-        if mgs_target.state in ['mounted', 'unmounted']:
-            steps.append((UnmountStep,
-                          {"target": mgs_target,
-                           "host": mgs_primary_mount.host}))
-
-        steps.append((MountOrImportStep,
-                      MountOrImportStep.create_parameters(mgs_target,
-                                                          mgs_primary_mount.host,
-                                                          False)))
+        # MGS needs to be started
+        if not mgs_target.active_mount:
+            raise RuntimeError("MGT needs to be running in order to remove the filesystem.")
 
         steps.append((PurgeFilesystemStep,
                       {'filesystem': self.filesystem,
-                       'mgs_device_path': mgs_primary_mount.volume_node.path,
-                       'mgs_device_type': mgs_primary_mount.volume_node.volume.storage_resource.to_resource_class().device_type(),
-                       'host': mgs_primary_mount.host}))
+                       'mgs_device_path': mgs_target.active_mount.volume_node.path,
+                       'mgs_device_type': mgs_target.active_mount.volume_node.volume.storage_resource.to_resource_class().device_type(),
+                       'host': mgs_target.active_mount.host}))
 
-        steps.append((MountOrImportStep,
-                      MountOrImportStep.create_parameters(mgs_target,
-                                                          mgs_primary_mount.host if mgs_target.state == 'mounted' else None,
-                                                          True)))
         return steps
 
     def on_success(self):

--- a/chroma-manager/tests/unit/services/job_scheduler/test_filesystem.py
+++ b/chroma-manager/tests/unit/services/job_scheduler/test_filesystem.py
@@ -163,19 +163,17 @@ class TestFSTransitions(JobTestCaseWithHost):
             ManagedFilesystem.objects.get(pk = self.fs.pk)
 
     def test_fs_removal_mgt_offline(self):
-        """Test that removing a filesystem whose MGT is offline leaves the MGT offline at completion"""
+        """Test that removing a filesystem whose MGT is offline starts the MGT and can remove successfully"""
         self.mgt.managedtarget_ptr = self.set_and_assert_state(self.mgt.managedtarget_ptr, 'unmounted')
         self.fs = self.set_and_assert_state(self.fs, 'removed')
-        self.assertState(self.mgt.managedtarget_ptr, 'unmounted')
+        self.assertState(self.mgt.managedtarget_ptr, 'mounted')
         with self.assertRaises(ManagedFilesystem.DoesNotExist):
             ManagedFilesystem.objects.get(pk = self.fs.pk)
 
     def test_fs_removal_mgt_online(self):
-        """Test that removing a filesystem whose MGT is online leaves the MGT online at completion, but
-        stops it in the course of the removal (for the debugfs-ing)"""
+        """Test removing a filesystem whose MGT is online."""
         self.mgt.managedtarget_ptr = self.set_and_assert_state(self.mgt.managedtarget_ptr, 'mounted')
-        with self.assertInvokes('stop_target', {'ha_label': freshen(self.mgt).ha_label}):
-            self.fs = self.set_and_assert_state(self.fs, 'removed')
+        self.fs = self.set_and_assert_state(self.fs, 'removed')
         self.assertState(self.mgt, 'mounted')
         with self.assertRaises(ManagedFilesystem.DoesNotExist):
             ManagedFilesystem.objects.get(pk = self.fs.pk)


### PR DESCRIPTION
Use the new 'lctl erase_lcfg' Lustre functionality to purge old
file systems from the MGS, rather than going in and modifying the
Lustre config directly. This has a few benefits:

  - MGS does not need to be stopped to purge a file system.
  - Can be used identically on ldiskfs or ZFS backed file systems.
  - Gets rid of one of our intermittent test failures where the
    RemoveFilesystemJob hangs.

Replace current method of purging filesystems with lctl erase_lcfg

  - Get rid of individual purge_filesystem functions in
    blockdevice_linux and blockdevice_zfs
  - Create one common shared purge_filesystem function that uses
    lctl erase_lcfg.
  - Update the unit tests for the expected change in commands
    executed.

Change-Id: Ie7bc9d242ce844c3068ff57cb3fd05c3ded0a8b9
Signed-off-by: Kelsey Prantis <kelsey.prantis@intel.com>
Reviewed-on: https://review.whamcloud.com/26821
Tested-by: Jenkins
Reviewed-by: Tom Nabarro <tom.nabarro@intel.com>
Tested-by: Chroma Test User
Reviewed-by: Will Johnson <william.c.johnson@intel.com>