### PR TITLE
Remove nodejs installation on the builder

### DIFF
--- a/scripts/jenkins_build
+++ b/scripts/jenkins_build
@@ -66,7 +66,8 @@ pre_build()
     # update modules
     scripts/update_chroma-externals.py
     run_pre_commit_hook
-    update_nodejs_version
+    # we don't currently need this
+    #update_nodejs_version
 }
 
 build_dependencies()


### PR DESCRIPTION
Now that we are a single branch, and solidly focused on always using the
latest nodejs, remove the installation on the builder prior to build.