### PR TITLE
Remove nodejs installation on the builder

### DIFF
--- a/chroma-manager/Makefile
+++ b/chroma-manager/Makefile
@@ -2,10 +2,9 @@ include ../include/Makefile.version
 
 NPM := $(shell if which npm &>/dev/null && npm -v; then true; else echo npm; fi)
 
-NPM_VERSION ?= 3.10.6
+NPM_VERSION ?= 4.6.1
 
 define set_env_for_npm
-export NPM_CONFIG_REGISTRY=https://ubit-artifactory-or.intel.com/artifactory/api/npm/iml-npm-repos/; \
 mkdir -p ~/.npm-global;                                                                              \
 mkdir -p ~/.npm-global-cache;                                                                        \
 export NPM_CONFIG_PYTHON=/usr/bin/python;                                                            \
@@ -79,14 +78,9 @@ develop: version ui-modules
 	python setup.py develop
 	./manage.py dev_setup $(DEV_SETUP_BUNDLES)
 
-$(HOME)/.node-gyp:
-	@echo "copying nodejs headers"; \
-	mkdir -p $HOME/.node-gyp && \
-	cp -r ../chroma-externals/node-gyp-headers/ $(HOME)/.node-gyp/
-
-npm: $(HOME)/.node-gyp
+npm:
 ifneq ($(NPM), $(NPM_VERSION))
-	curl https://ubit-artifactory-or.intel.com/artifactory/api/npm/iml-npm-repos/npm/-/npm-$(NPM_VERSION).tgz > /tmp/npm-$(NPM_VERSION).tgz
+	curl https://registry.npmjs.org/npm/-/npm-$(NPM_VERSION).tgz > /tmp/npm-$(NPM_VERSION).tgz
 	tar -xzf /tmp/npm-$(NPM_VERSION).tgz -C /tmp/
 	set -e;                                                               \
 	$(set_env_for_npm) &&                                                 \

--- a/chroma-manager/tests/framework/utils/make_develop.sh
+++ b/chroma-manager/tests/framework/utils/make_develop.sh
@@ -40,7 +40,6 @@ EOF1
 
 mkdir -p ~/.npm-global
 export NPM_CONFIG_PYTHON=/usr/bin/python
-export NPM_CONFIG_REGISTRY=https://ubit-artifactory-or.intel.com/artifactory/api/npm/iml-npm-repos/
 export NPM_CONFIG_PREFIX=~/.npm-global
 export PATH=\$PATH:~/.npm-global/bin
 make develop"

--- a/chroma-manager/ui-modules/package.json
+++ b/chroma-manager/ui-modules/package.json
@@ -8,8 +8,8 @@
     "@iml/gui": "6.0.9",
     "@iml/old-gui": "1.1.2",
     "intel-help-docs": "1.2.0",
-    "intel-realtime": "5.1.0",
-    "@iml/view-server": "6.3.4",
+    "intel-realtime": "5.1.1",
+    "@iml/view-server": "6.3.5",
     "@iml/socket-worker": "3.2.0"
   }
 }

--- a/scripts/jenkins_build
+++ b/scripts/jenkins_build
@@ -66,7 +66,8 @@ pre_build()
     # update modules
     scripts/update_chroma-externals.py
     run_pre_commit_hook
-    update_nodejs_version
+    # we don't currently need this
+    #update_nodejs_version
 }
 
 build_dependencies()


### PR DESCRIPTION
Now that we are a single branch, and solidly focused on always using the
latest nodejs, remove the installation on the builder prior to build.

remove all refs to artifactory.

Signed-off-by: Joe Grund <grundjoseph@gmail.com>