### PR TITLE
Remove Downloading of npm during build.

### DIFF
--- a/chroma-manager/Makefile
+++ b/chroma-manager/Makefile
@@ -1,19 +1,5 @@
 include ../include/Makefile.version
 
-NPM := $(shell if which npm &>/dev/null && npm -v; then true; else echo npm; fi)
-
-NPM_VERSION ?= 4.6.1
-
-define set_env_for_npm
-mkdir -p ~/.npm-global;                                                                              \
-mkdir -p ~/.npm-global-cache;                                                                        \
-export NPM_CONFIG_PYTHON=/usr/bin/python;                                                            \
-export NPM_CONFIG_CACHE=~/.npm-global-cache;                                                         \
-export NPM_CONFIG_CACHE_MIN=360000;                                                                  \
-export NPM_CONFIG_PREFIX=~/.npm-global;                                                              \
-export PATH=~/.npm-global/bin:$$PATH
-endef
-
 ARCH := $(shell echo $$(uname -m))
 
 # Fixup proxies if needed
@@ -78,38 +64,13 @@ develop: version ui-modules
 	python setup.py develop
 	./manage.py dev_setup $(DEV_SETUP_BUNDLES)
 
-npm:
-ifneq ($(NPM), $(NPM_VERSION))
-	curl https://registry.npmjs.org/npm/-/npm-$(NPM_VERSION).tgz > /tmp/npm-$(NPM_VERSION).tgz
-	tar -xzf /tmp/npm-$(NPM_VERSION).tgz -C /tmp/
-	set -e;                                                               \
-	$(set_env_for_npm) &&                                                 \
-	/tmp/package/bin/npm-cli.js install -g /tmp/npm-$(NPM_VERSION).tgz -d
-endif
-
-ui-modules: npm
+ui-modules:
 	@echo "Setting up ui-modules"; \
 	set -e;                        \
-	$(set_env_for_npm) &&          \
 	export NODE_ENV=production &&  \
 	cd ui-modules &&               \
 	npm i -d &&                    \
 	npm prune
-
-ui-modules-dev: npm
-	@echo "Setting up ui-modules for dev"; \
-	cd ui-modules && \
-	npm i && \
-	cd node_modules/@iml/gui && \
-	npm i --only=dev && \
-	cd ../../intel-realtime && \
-	npm i --only=dev && \
-	cd ../@iml/view-server && \
-	npm i --only=dev;
-
-
-gui: ui-modules
-	@echo "Building GUI for deployment";
 
 nuke_db:
 	@$(ALWAYS_NUKE_DB) && { \
@@ -208,7 +169,7 @@ feature_tests:
 
 tests test: unit_tests agent_tests feature_tests integration_tests service_tests
 
-tarball: version gui
+tarball: version ui-modules
 	rm -f MANIFEST
 	python scripts/production_supervisord.py supervisord.conf > production_supervisord.conf
 	# workaround setuptools
@@ -273,4 +234,4 @@ docs: requirements.txt version
 	fi;                                                             \
 	$(MAKE) -C docs/ && cp docs/dist/*.tar.gz dist/
 
-.PHONY: docs download gui ui-modules npm
+.PHONY: docs download ui-modules

--- a/chroma-manager/tests/framework/utils/make_develop.sh
+++ b/chroma-manager/tests/framework/utils/make_develop.sh
@@ -38,8 +38,5 @@ import logging
 LOG_LEVEL = logging.DEBUG
 EOF1
 
-mkdir -p ~/.npm-global
 export NPM_CONFIG_PYTHON=/usr/bin/python
-export NPM_CONFIG_PREFIX=~/.npm-global
-export PATH=\$PATH:~/.npm-global/bin
 make develop"


### PR DESCRIPTION
We are currently using a bridged version of node
sans npm.

We were using this code to pull npm for builds, however
npm has been added to the builder, which obviates this.

Remove npm and the code that setup a new npm root.
Since we are staying current with node / npm there
is no need to jail a newer npm setup.

Signed-off-by: Joe Grund <joe.grund@intel.com>