### PR TITLE
HYD-7338 Fix exceptions due to missing config store directories

### DIFF
--- a/chroma-agent/chroma_agent/action_plugins/agent_setup.py
+++ b/chroma-agent/chroma_agent/action_plugins/agent_setup.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2015 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -42,6 +42,7 @@ agent_service = ServiceControl.create('chroma-agent')
 
 
 def _service_is_running():
+    # returns True if running
     return agent_service.running
 
 
@@ -79,8 +80,7 @@ def deregister_server():
 
 
 def register_server(url, ca, secret, address =None):
-
-    if _service_is_running() is None:
+    if _service_is_running() is True:
         console_log.warning("chroma-agent service was running before registration, stopping.")
         agent_service.stop()
 
@@ -110,8 +110,8 @@ def register_server(url, ca, secret, address =None):
 
 
 def reregister_server(url, address):
-    "Update manager url and register agent address with manager."
-    if _service_is_running() is None:
+    """ Update manager url and register agent address with manager """
+    if _service_is_running() is True:
         console_log.warning("chroma-agent service was running before registration, stopping.")
         agent_service.stop()
 

--- a/chroma-agent/chroma_agent/agent_daemon.py
+++ b/chroma-agent/chroma_agent/agent_daemon.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2016 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -168,8 +168,9 @@ def main():
         daemon_log.info("Entering main loop")
         try:
             conf = config.get('settings', 'server')
-        except KeyError:
-            daemon_log.error("No configuration found (must be registered before running the agent service)")
+        except (KeyError, TypeError) as e:
+            daemon_log.error("No configuration found (must be registered before running the agent service), "
+                             "details: %s" % e)
             return
 
         if config.profile_managed is False:


### PR DESCRIPTION
During agent daemon start-up, the settings directory of the config
store sometimes cannot be found and results in an exception in the
chroma-agent damon log.

The explanation for this is that the chroma-agent service has been
started before agent registration (in agent_setup.py) has completed
(during which the config store directories are created).

This situation can occur due to a bug when checking if the service
is already running during chroma-agent registration. After the
fix is applied, if this situation occurs, a message should appear
in the agent daemon log indicating "service was running before
registration, stopping.".

  - stop agent service if it is already running at the beginning
    of the agent_setup.py 'register' function