### PR TITLE
Remove Jenkins auth

### DIFF
--- a/chroma-dependencies/include/Makefile.jenkins_meta
+++ b/chroma-dependencies/include/Makefile.jenkins_meta
@@ -1,4 +1,1 @@
-JENKINS_USERNAME	?= jenkins-pull
-JENKINS_PASSWORD	?= Aitahd9u
-JENKINS_CREDENTIALS	?= $(JENKINS_USERNAME):$(JENKINS_PASSWORD)@
-JENKINS_ROOT_URL	:= https://$(JENKINS_CREDENTIALS)build.hpdd.intel.com
+JENKINS_ROOT_URL	:= https://build.hpdd.intel.com

--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
@@ -11,10 +11,9 @@ export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"$CHROMA_DIR/chroma-ma
 
 cd $WORKSPACE
 # Copy a fingerprinted file so we can link together the projects in jenkins.
-set +x  # DONT REMOVE/COMMENT or you will risk exposing the jenkins-pull api token in the console logs.
-echo "+ curl -f -k -O -u $JENKINS_USER:********* \"$JOB_URL/$ARCHIVE_NAME\""
-curl -f -k -O -u $JENKINS_USER:$JENKINS_PULL "$JOB_URL/$ARCHIVE_NAME"
-set -x
+
+echo "+ curl -f -k -O \"$JOB_URL/$ARCHIVE_NAME\""
+curl -f -k -O "$JOB_URL/$ARCHIVE_NAME"
 
 got_aborted=false
 # Gather logs from nodes and release the cluster at exit

--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
@@ -30,15 +30,6 @@ $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/provision
 
 # see if this cures the 401 errors from jenkins
 eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CONFIG")
-pdsh -R ssh -l root -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]} ${WORKERS[@]} $CHROMA_MANAGER $TEST_RUNNER) "exec 2>&1; set -xe
-if [ -f /etc/yum.repos.d/autotest.repo ]; then
-    set +x
-    sed -i -e 's/Aitahd9u/$JENKINS_PULL/g' /etc/yum.repos.d/autotest.repo
-    set -x
-fi" | dshbak -c
-if [ ${PIPESTATUS[0]} != 0 ]; then
-    exit 1
-fi
 
 $CHROMA_DIR/chroma-manager/tests/framework/integration/existing_filesystem_configuration/cluster_setup
 

--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
@@ -12,7 +12,6 @@ export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"$CHROMA_DIR/chroma-ma
 cd $WORKSPACE
 # Copy a fingerprinted file so we can link together the projects in jenkins.
 
-echo "+ curl -f -k -O \"$JOB_URL/$ARCHIVE_NAME\""
 curl -f -k -O "$JOB_URL/$ARCHIVE_NAME"
 
 got_aborted=false

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -11,11 +11,8 @@ CURRENT_IEEL_VERSION=$(make -f include/Makefile.version .ieel_version 2>/dev/nul
 SLAVE=${slave:?"Need to set slave"}
 
 cd $WORKSPACE
-
-set +x  # DONT REMOVE/COMMENT or you will risk exposing the jenkins-pull api token in the console logs.
-echo "+ curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz -u $JENKINS_USER:********* \"$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz\""
-curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz -u $JENKINS_USER:$JENKINS_PULL "$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz"
-set -x
+echo "+ curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz \"$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz\""
+curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz "$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz"
 
 # Gather logs from nodes and release the cluster at exit
 trap "set +e

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -11,7 +11,6 @@ CURRENT_IEEL_VERSION=$(make -f include/Makefile.version .ieel_version 2>/dev/nul
 SLAVE=${slave:?"Need to set slave"}
 
 cd $WORKSPACE
-echo "+ curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz \"$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz\""
 curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz "$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz"
 
 # Gather logs from nodes and release the cluster at exit

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -33,9 +33,6 @@ if [ "$TEST_DISTRO_NAME" = "el" -a                  \
     exit 0
 fi
 
-ssh root@$TEST_RUNNER "exec 2>&1; set -e; set +x
-sed -i -e 's/Aitahd9u/"$JENKINS_PULL"/g' /etc/yum.repos.d/autotest.repo"
-
 # see if this mitigates the near constant failure to complete a yum upgrade from the RH CDN
 pdsh -l root -R ssh -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]} ${WORKERS[@]}) "exec 2>&1; set -xe
 cat <<\"EOF\" >> /etc/yum.conf
@@ -50,9 +47,6 @@ fi
 export RHEL
 
 echo "Beginning automated test run..."
-set +x
-export JENKINS_PULL
-set -x
 $CHROMA_DIR/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
 $CHROMA_DIR/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
 echo "Automated test run complete."

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -42,23 +42,17 @@ if [ ${PIPESTATUS[0]} != 0 ]; then
     exit 1
 fi
 
-if [ -z "$JENKINS_PULL" ]; then
-    JENKINS_PULL="2cf9b55238c654b00bc37a6e8ccc4caf"
-fi
 # first fetch and install chroma 3.1.1.0
 BUILD_JOB=ieel
 BUILD_NUM=37
-set +x
-echo "++ curl -s -k -u \"${JENKINS_USER}:**********\" \"${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/api/xml?xpath=*/artifact/fileName&wrapper=foo\"
+echo "++ curl -s -k \"${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/api/xml?xpath=*/artifact/fileName&wrapper=foo\"
 ++ sed -e 's/.*>\([i]\?ee[l]\?-[0-9\.][0-9\.]*.tar.gz\)<.*/\1/')"
-IEEL_FROM_ARCHIVE=$(curl -s -k -u "${JENKINS_USER}:${JENKINS_PULL}" "${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/api/xml?xpath=*/artifact/fileName&wrapper=foo" | sed -e 's/.*>\([i]\?ee[l]\?-[0-9\.][0-9\.]*.tar.gz\)<.*/\1/')
-set -x
+IEEL_FROM_ARCHIVE=$(curl -s -k "${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/api/xml?xpath=*/artifact/fileName&wrapper=foo" | sed -e 's/.*>\([i]\?ee[l]\?-[0-9\.][0-9\.]*.tar.gz\)<.*/\1/')
 IEEL_FROM_VER="${IEEL_FROM_ARCHIVE#*-}"
 IEEL_FROM_VER="${IEEL_FROM_VER%.tar.gz}"
-set +x
-echo "+ curl -k -O -u \"${JENKINS_USER}:***********\" \"${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/artifact/$IEEL_FROM_ARCHIVE\""
-curl -k -O -u "${JENKINS_USER}:${JENKINS_PULL}" "${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/artifact/$IEEL_FROM_ARCHIVE"
-set -x
+
+echo "+ curl -k -O \"${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/artifact/$IEEL_FROM_ARCHIVE\""
+curl -k -O "${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/artifact/$IEEL_FROM_ARCHIVE"
 
 # Install and setup old manager
 scp $IEEL_FROM_ARCHIVE $CHROMA_DIR/chroma-manager/tests/utils/install.exp root@$CHROMA_MANAGER:/tmp

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -45,13 +45,10 @@ fi
 # first fetch and install chroma 3.1.1.0
 BUILD_JOB=ieel
 BUILD_NUM=37
-echo "++ curl -s -k \"${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/api/xml?xpath=*/artifact/fileName&wrapper=foo\"
-++ sed -e 's/.*>\([i]\?ee[l]\?-[0-9\.][0-9\.]*.tar.gz\)<.*/\1/')"
 IEEL_FROM_ARCHIVE=$(curl -s -k "${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/api/xml?xpath=*/artifact/fileName&wrapper=foo" | sed -e 's/.*>\([i]\?ee[l]\?-[0-9\.][0-9\.]*.tar.gz\)<.*/\1/')
 IEEL_FROM_VER="${IEEL_FROM_ARCHIVE#*-}"
 IEEL_FROM_VER="${IEEL_FROM_VER%.tar.gz}"
 
-echo "+ curl -k -O \"${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/artifact/$IEEL_FROM_ARCHIVE\""
 curl -k -O "${JENKINS_URL}job/$BUILD_JOB/$BUILD_NUM/artifact/$IEEL_FROM_ARCHIVE"
 
 # Install and setup old manager

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
@@ -32,19 +32,6 @@ $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/provision
 
 # see if this cures the 401 errors from jenkins
 eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CONFIG")
-pdsh -R ssh -l root -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]} ${WORKERS[@]} $CHROMA_MANAGER $TEST_RUNNER) "exec 2>&1; set -xe
-if [ -f /etc/yum.repos.d/autotest.repo ]; then
-    set +x
-    sed -i -e 's/Aitahd9u/$JENKINS_PULL/g' /etc/yum.repos.d/autotest.repo
-    set -x
-fi
-cd /etc/yum.repos.d/
-for f in *.repo; do
-  sed -i -e 's/distro=el6\.[0-9]/distro=el6.4/' \$f
-done" | dshbak -c
-if [ ${PIPESTATUS[0]} != 0 ]; then
-    exit 1
-fi
 
 echo "Beginning automated test run..."
 export MEASURE_COVERAGE=$MEASURE_COVERAGE

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
@@ -14,10 +14,8 @@ export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"$CHROMA_DIR/chroma-ma
 
 if $JENKINS; then
     cd $WORKSPACE
-    set +x  # DONT REMOVE/COMMENT or you will risk exposing the jenkins-pull api token in the console logs.
-    echo "+ curl -f -k -O -u $JENKINS_USER:********** \"$JOB_URL/$ARCHIVE_NAME\""
-    curl -f -k -O -u $JENKINS_USER:$JENKINS_PULL "$JOB_URL/$ARCHIVE_NAME"
-    set -x
+    echo "+ curl -f -k -O \"$JOB_URL/$ARCHIVE_NAME\""
+    curl -f -k -O "$JOB_URL/$ARCHIVE_NAME"///
 fi
 
 got_aborted=false

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
@@ -14,8 +14,7 @@ export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"$CHROMA_DIR/chroma-ma
 
 if $JENKINS; then
     cd $WORKSPACE
-    echo "+ curl -f -k -O \"$JOB_URL/$ARCHIVE_NAME\""
-    curl -f -k -O "$JOB_URL/$ARCHIVE_NAME"///
+    curl -f -k -O "$JOB_URL/$ARCHIVE_NAME"
 fi
 
 got_aborted=false

--- a/chroma-manager/tests/framework/integration/upgrade_os/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/upgrade_os/jenkins_steps/main
@@ -10,9 +10,7 @@ export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"chroma/chroma-manager
 SLAVE=${slave:?"Need to set slave"}
 
 cd $WORKSPACE
-set +x  # DONT REMOVE/COMMENT or you will risk exposing the jenkins-pull api token in the console logs.
-curl -f -k -O -u $JENKINS_USER:$JENKINS_PULL "$JOB_URL/chroma-bundles/$ARCHIVE_NAME"
-set -x
+curl -f -k -O "$JOB_URL/chroma-bundles/$ARCHIVE_NAME"
 
 # Gather logs from nodes and release the cluster at exit
 cleanup() {

--- a/chroma-manager/tests/framework/integration/upgrade_os/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/upgrade_os/jenkins_steps/main
@@ -43,11 +43,6 @@ chroma/chroma-manager/tests/framework/utils/provisioner_interface/provision_clus
 # see if this cures the 401 errors from jenkins
 eval $(python chroma/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CONFIG")
 pdsh -R ssh -l root -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]} ${WORKERS[@]} $CHROMA_MANAGER $TEST_RUNNER) "exec 2>&1; set -xe
-if [ -f /etc/yum.repos.d/autotest.repo ]; then
-    set +x
-    sed -i -e 's/Aitahd9u/$JENKINS_PULL/g' /etc/yum.repos.d/autotest.repo
-    set -x
-fi
 cd /etc/yum.repos.d/
 for f in *.repo; do
   sed -i -e 's/distro=el6\.[0-9]/distro=el6.4/' \$f

--- a/chroma-manager/tests/framework/services/jenkins_steps/main
+++ b/chroma-manager/tests/framework/services/jenkins_steps/main
@@ -27,7 +27,7 @@ eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CO
 pdsh -R ssh -l root -S -w $CHROMA_MANAGER $TEST_RUNNER "exec 2>&1; set -xe
 cd /etc/yum.repos.d/
 for f in *.repo; do
-  sed -i -e \"s/distro=${TEST_DISTRO_NAME}${TEST_DISTRO_VERSION}/distro=$JENKINS_DISTRO/\" -e 's/http:\/\/jenkins-pull/https:\/\/jenkins-pull/g' \$f
+  sed -i -e \"s/distro=${TEST_DISTRO_NAME}${TEST_DISTRO_VERSION}/distro=$JENKINS_DISTRO/\" \$f
 done" | dshbak -c
 if [ ${PIPESTATUS[0]} != 0 ]; then
     exit 1

--- a/chroma-manager/tests/framework/test_reporting/aggregate_test_results.py
+++ b/chroma-manager/tests/framework/test_reporting/aggregate_test_results.py
@@ -2,7 +2,7 @@
 # Simple script to accept the jenkins json api output of $BUILD_URL/api/json?tree=runs[fingerprint[usage[name,ranges[ranges[end]]]]]
 # and return the name and build number for each job triggered downstream of the original build in BUILD_URL.
 #
-# Usage: ./aggregate_test_results.py jenkins_url username password build_job_name build_job_build_number valid_test_jobs required_tests
+# Usage: ./aggregate_test_results.py jenkins_url build_job_name build_job_build_number valid_test_jobs required_tests
 
 from collections import defaultdict
 import errno
@@ -126,17 +126,15 @@ if __name__ == '__main__':
 
     # Store the command line arguments
     jenkins_url = sys.argv[1]
-    username = sys.argv[2]
-    password = sys.argv[3]
-    build_job_name = sys.argv[4]
-    build_job_build_number = int(sys.argv[5])
-    valid_test_jobs = set(sys.argv[6].split())
-    required_tests = set(sys.argv[7].split())
+    build_job_name = sys.argv[2]
+    build_job_build_number = int(sys.argv[3])
+    valid_test_jobs = set(sys.argv[4].split())
+    required_tests = set(sys.argv[5].split())
 
     # Fetch the downstream build info from jenkins
     requests.packages.urllib3.disable_warnings()
-    req = Requester(username, password, baseurl=jenkins_url, ssl_verify=False)
-    jenkins = api.Jenkins(jenkins_url, username=username, password=password, requester=req)
+    req = Requester(None, None, baseurl=jenkins_url, ssl_verify=False)
+    jenkins = api.Jenkins(jenkins_url, requester=req)
     assert jenkins.get_jobs_list()  # A test we are logged in
     job = jenkins.get_job(build_job_name)
     build = job.get_build(build_job_build_number)

--- a/chroma-manager/tests/framework/test_reporting/jenkins_steps/main
+++ b/chroma-manager/tests/framework/test_reporting/jenkins_steps/main
@@ -14,8 +14,6 @@ REQUIRED_TEST_JOBS="chroma-integration-tests-existing-filesystem-configuration c
 cd $WORKSPACE
 shopt -s expand_aliases
 alias test_aggregation="python chroma_test_env/chroma/chroma-manager/tests/framework/test_reporting/aggregate_test_results.py '${JENKINS_URL}' '${BUILD_JOB_NAME}' '${BUILD_JOB_BUILD_NUMBER}' '$VALID_TEST_JOBS' '$REQUIRED_TEST_JOBS'"
-sanitized_alias=$(echo $(type test_aggregation) | sed -e "s/^test_aggregation is aliased to \`//" -e "s/'$//")
-echo "+ $sanitized_alias"
 test_results=$(test_aggregation 2>&1) || true
 
 cat test_aggregation.log || true

--- a/chroma-manager/tests/framework/test_reporting/jenkins_steps/main
+++ b/chroma-manager/tests/framework/test_reporting/jenkins_steps/main
@@ -12,14 +12,11 @@ VALID_TEST_JOBS="chroma-integration-tests-existing-filesystem-configuration chro
 REQUIRED_TEST_JOBS="chroma-integration-tests-existing-filesystem-configuration chroma-unit-tests chroma-integration-tests-shared-storage-configuration-with-simulator chroma-tests-services chroma-integration-tests-shared-storage-configuration-brian chroma-upgrade-tests"
 
 cd $WORKSPACE
-# Do not change +x below or risk exposing the jenkins-pull password in the console logs!
-set +x
 shopt -s expand_aliases
-alias test_aggregation="python chroma_test_env/chroma/chroma-manager/tests/framework/test_reporting/aggregate_test_results.py '${JENKINS_URL}' '${JENKINS_USER:-jenkins-pull}' '$JENKINS_PULL' '${BUILD_JOB_NAME}' '${BUILD_JOB_BUILD_NUMBER}' '$VALID_TEST_JOBS' '$REQUIRED_TEST_JOBS'"
+alias test_aggregation="python chroma_test_env/chroma/chroma-manager/tests/framework/test_reporting/aggregate_test_results.py '${JENKINS_URL}' '${BUILD_JOB_NAME}' '${BUILD_JOB_BUILD_NUMBER}' '$VALID_TEST_JOBS' '$REQUIRED_TEST_JOBS'"
 sanitized_alias=$(echo $(type test_aggregation) | sed -e "s/$JENKINS_PULL/**********/g" -e "s/^test_aggregation is aliased to \`//" -e "s/'$//")
 echo "+ $sanitized_alias"
 test_results=$(test_aggregation 2>&1) || true
-set -x
 
 cat test_aggregation.log || true
 echo "Test aggregation script results: $test_results"

--- a/chroma-manager/tests/framework/test_reporting/jenkins_steps/main
+++ b/chroma-manager/tests/framework/test_reporting/jenkins_steps/main
@@ -14,7 +14,7 @@ REQUIRED_TEST_JOBS="chroma-integration-tests-existing-filesystem-configuration c
 cd $WORKSPACE
 shopt -s expand_aliases
 alias test_aggregation="python chroma_test_env/chroma/chroma-manager/tests/framework/test_reporting/aggregate_test_results.py '${JENKINS_URL}' '${BUILD_JOB_NAME}' '${BUILD_JOB_BUILD_NUMBER}' '$VALID_TEST_JOBS' '$REQUIRED_TEST_JOBS'"
-sanitized_alias=$(echo $(type test_aggregation) | sed -e "s/$JENKINS_PULL/**********/g" -e "s/^test_aggregation is aliased to \`//" -e "s/'$//")
+sanitized_alias=$(echo $(type test_aggregation) | sed -e "s/^test_aggregation is aliased to \`//" -e "s/'$//")
 echo "+ $sanitized_alias"
 test_results=$(test_aggregation 2>&1) || true
 

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -4,14 +4,6 @@ else
     export JENKINS=false
 fi
 
-if $JENKINS; then
-    # auth.sh contains the JENKINS_PULL environmental variable so we can avoid
-    # printing it into the console in plaintext calling this script.
-    set +x  # DONT REMOVE/COMMENT or you will risk exposing the jenkins-pull api token in the console logs.
-    . $HOME/auth.sh
-    set -x
-fi
-
 [ -r localenv ] && . localenv
 
 spacelist_to_commalist() {
@@ -74,12 +66,6 @@ set_defaults() {
     rm -f /tmp/env-"$JOB_NAME"-"$BUILD_NUMBER"
 
     if $JENKINS; then
-        # Variables that we expect to be set upstream, no "default"
-        export JENKINS_USER=${JENKINS_USER:-jenkins-pull}
-        set +x  # DONT REMOVE/COMMENT or you will risk exposing the jenkins-pull api token in the console logs.
-        export JENKINS_PULL=${JENKINS_PULL:?"Need to set JENKINS_PULL"}
-        set -x
-
         JOB_NAME=${JOB_NAME%%/*}
         export JOB_NAME=${JOB_NAME:?"Need to set JOB_NAME"}
         export BUILD_JOB_NAME=${BUILD_JOB_NAME:?"Need to set BUILD_JOB_NAME"}


### PR DESCRIPTION
Remove all instances of jenkins auth.
We will not need it going forward.

Signed-off-by: Joe Grund <joe.grund@intel.com>