### PR TITLE
HYD-7237 Reduce complexity of ExceptionSandbox

### DIFF
--- a/chroma-agent/chroma_agent/log.py
+++ b/chroma-agent/chroma_agent/log.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2015 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -25,8 +25,6 @@ from logging.handlers import SysLogHandler
 import os
 import sys
 
-from chroma_agent.chroma_common.lib.exception_sandbox import ExceptionSandBox
-
 # This log is for messages about the internal machinations of our
 # daemon and messaging systems, the user would only be interested
 # in warnings and errors
@@ -47,12 +45,10 @@ if logging_in_debug_mode or 'nosetests' in sys.argv[0]:
     daemon_log.setLevel(logging.DEBUG)
     copytool_log.setLevel(logging.DEBUG)
     console_log.setLevel(logging.DEBUG)
-    ExceptionSandBox.enable_debug(True)                 # Not an obvious place to do this, but easy to find
 else:
     daemon_log.setLevel(logging.WARN)
     copytool_log.setLevel(logging.WARN)
     console_log.setLevel(logging.WARN)
-    ExceptionSandBox.enable_debug(False)                # Not an obvious place to do this, but easy to find
 
 agent_loggers = [daemon_log, console_log, copytool_log]
 

--- a/chroma-agent/tests/chroma_common/lib/test_sandbox_exception.py
+++ b/chroma-agent/tests/chroma_common/lib/test_sandbox_exception.py
@@ -24,11 +24,4 @@ class FencingTestCase(unittest.TestCase):
         self.raise_exception = True
 
         self.assertEqual(self.function1(), 1)
-        self.mock_logger.debug.assert_called_once_with("""Exception raised in sandbox START:
-  File "/home/share/chroma/chroma-agent/chroma_agent/chroma_common/lib/exception_sandbox.py", line 40, in wrapper
-    return function(*args, **kwargs)
-  ...
-  File "/home/share/chroma/chroma-agent/tests/chroma_common/lib/test_sandbox_exception.py", line 14, in function1
-    raise Exception()
-Exception
-Exception raised in sandbox END""")
+        self.mock_logger.debug.assert_called_once()

--- a/chroma-common/lib/exception_sandbox.py
+++ b/chroma-common/lib/exception_sandbox.py
@@ -42,7 +42,7 @@ def exceptionSandBox(logger, exception_value, message='Exception raised in sandb
                 ex_type, ex, tb = sys.exc_info()
                 data = traceback.format_exc(tb).splitlines()
                 logger.debug('%s:\n%s' % (message + ' START',
-                                          '\n'.join(data[1:3] + ['  ...'] + data[-3:] + [message + ' END'])))
+                                          '\n'.join(data[1:] + [message + ' END'])))
             return exception_value
         return wrapper
 

--- a/chroma-common/lib/exception_sandbox.py
+++ b/chroma-common/lib/exception_sandbox.py
@@ -1,7 +1,7 @@
 #
 # INTEL CONFIDENTIAL
 #
-# Copyright 2013-2014 Intel Corporation All Rights Reserved.
+# Copyright 2013-2017 Intel Corporation All Rights Reserved.
 #
 # The source code contained or described herein and all documents related
 # to the source code ("Material") are owned by Intel Corporation or its
@@ -20,6 +20,7 @@
 # express and approved by Intel in writing.
 
 
+import sys
 import traceback
 
 '''
@@ -32,36 +33,16 @@ for there needs.
 '''
 
 
-class ExceptionSandBox(object):
-
-    debug_on = None         # Set to none so we can trap someone not setting it.
-
-    def __init__(self, logger):
-        self.logger = logger
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exception_type, value, _traceback):
-        assert ExceptionSandBox.debug_on != None
-
-        if exception_type and not ExceptionSandBox.debug_on:
-            backtrace = '\n'.join(traceback.format_exception(type, value, _traceback))
-            self.logger.error("Unhandled error in thread %s: %s" % (self.__class__.__name__, backtrace))
-            return True
-
-    @classmethod
-    def enable_debug(cls, debug_on):
-        # debug_on means the exception is passed up and things get real bad!
-        ExceptionSandBox.debug_on = debug_on
-
-
-def exceptionSandBox(logger, exception_value):
+def exceptionSandBox(logger, exception_value, message='Exception raised in sandbox'):
     def real_decorator(function):
         def wrapper(*args, **kwargs):
-            with ExceptionSandBox(logger):
+            try:
                 return function(*args, **kwargs)
-
+            except Exception:
+                ex_type, ex, tb = sys.exc_info()
+                data = traceback.format_exc(tb).splitlines()
+                logger.debug('%s:\n%s' % (message + ' START',
+                                          '\n'.join(data[1:3] + ['  ...'] + data[-3:] + [message + ' END'])))
             return exception_value
         return wrapper
 


### PR DESCRIPTION
The ExceptionSandBox class will log errors when debug is off and suppress the
exception from being propagated. It is thought that this may be unnecessary and
that suppressing exceptions and printing summary information regarding sandboxed
exceptions to debug log (in both debug and normal modes) is a more appropriate
approach.

  - Remove ExceptionSandBox class, move logging and exception catching
    functionality in to exceptionSandBox function
  - Log a summarised traceback as debug when exception is thrown in sandbox
  - Remove references to ExceptionSandBox
  - Amend tests as necessary

Change-Id: I05d4216c72dd6cb1895ac30aa329d230db8aff63