### PR TITLE
Instruct any caching proxies to only cache packages

### DIFF
--- a/chroma-manager/tests/framework/utils/cluster_setup.sh
+++ b/chroma-manager/tests/framework/utils/cluster_setup.sh
@@ -21,6 +21,13 @@ pdsh -l root -R ssh -S -w $(spacelist_to_commalist $ALL_NODES) "exec 2>&1; set -
 cat <<\"EOF\" >> /root/.ssh/authorized_keys
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrcI6x6Fv2nzJwXP5mtItOcIDVsiD0Y//LgzclhRPOT9PQ/jwhQJgrggPhYr5uIMgJ7szKTLDCNtPIXiBEkFiCf9jtGP9I6wat83r8g7tRCk7NVcMm0e0lWbidqpdqKdur9cTGSOSRMp7x4z8XB8tqs0lk3hWefQROkpojzSZE7fo/IT3WFQteMOj2yxiVZYFKJ5DvvjdN8M2Iw8UrFBUJuXv5CQ3xV66ZvIcYkth3keFk5ZjfsnDLS3N1lh1Noj8XbZFdSRC++nbWl1HfNitMRm/EBkRGVP3miWgVNfgyyaT9lzHbR8XA7td/fdE5XrTpc7Mu38PE7uuXyLcR4F7l brian@brian-laptop
 EOF
+# instruct any caching proxies to only cache packages
+ed /etc/yum.conf <<EOF
+/^$/i
+http_caching=packages
+.
+wq
+EOF
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 yum-config-manager --enable addon-epel\$(rpm --eval %rhel)-x86_64
 yum-config-manager --add-repo https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/


### PR DESCRIPTION
Since caching metadata can result in coherency problems when
the metadata files are updated and the repomd.xml file is cached
and stale.