### PR TITLE
Firewall intermittently disabled/inactive during SSI runs

### DIFF
--- a/chroma-manager/tests/utils/remote_firewall_control.py
+++ b/chroma-manager/tests/utils/remote_firewall_control.py
@@ -204,7 +204,19 @@ class RemoteFirewallControlFirewallCmd(RemoteFirewallControl):
         result = self.remote_access_func(self.address, self.firewall_list_cmd)
 
         if result.rc != 0:
-            raise RuntimeError('process_rules(): remote shell command failed unexpectedly, is firewall-cmd running?')
+            from chroma_common.lib.shell import Shell
+            raise RuntimeError('''process_rules(): remote shell command failed unexpectedly (%s), is firewall-cmd running? (%s) (%s)
+systemctl status firewalld:
+%s
+
+systemctl status polkit:
+%s
+
+journalctl -n 100:
+%s''' % (result.rc, result.stdout, result.stderr,
+         Shell.run(['systemctl', 'status', 'firewalld']).stdout,
+         Shell.run(['systemctl', 'status', 'polkit']).stdout,
+         Shell.run(['journalctl', '-n', '100']).stdout))
 
         if result.stdout.strip() == '':
             return None


### PR DESCRIPTION
Firewall seems to be occasionally disabled on manager host during
SSI runs. this causes intermittent test failures.

   - Add command address and result to Exception output to clarify
