### PR TITLE
Add Notify triggers for chroma_core_alertstate.

### DIFF
--- a/chroma-manager/chroma_core/migrations/0033_health_status_notify.py
+++ b/chroma-manager/chroma_core/migrations/0033_health_status_notify.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.execute("""
+CREATE OR REPLACE FUNCTION table_update_notify() RETURNS trigger AS $$
+DECLARE
+  id bigint;
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    id = NEW.id;
+  ELSE
+    id = OLD.id;
+  END IF;
+
+  PERFORM pg_notify('table_update', TG_OP || ',' || TG_TABLE_NAME || ',' || id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER chroma_core_alertstate_notify_update
+ON chroma_core_alertstate;
+
+DROP TRIGGER chroma_core_alertstate_notify_insert
+ON chroma_core_alertstate;
+
+DROP TRIGGER chroma_core_alertstate_notify_delete
+ON chroma_core_alertstate;
+
+CREATE TRIGGER chroma_core_alertstate_notify_update
+AFTER UPDATE ON chroma_core_alertstate
+FOR EACH ROW EXECUTE PROCEDURE table_update_notify();
+
+CREATE TRIGGER chroma_core_alertstate_notify_insert
+AFTER INSERT ON chroma_core_alertstate
+FOR EACH ROW EXECUTE PROCEDURE table_update_notify();
+
+CREATE TRIGGER chroma_core_alertstate_notify_delete
+AFTER DELETE ON chroma_core_alertstate
+FOR EACH ROW EXECUTE PROCEDURE table_update_notify();
+""")
+
+    def backwards(self, orm):
+        db.execute("""
+DROP TRIGGER chroma_core_alertstate_notify_update
+ON chroma_core_alertstate;
+
+DROP TRIGGER chroma_core_alertstate_notify_insert
+ON chroma_core_alertstate;
+
+DROP TRIGGER chroma_core_alertstate_notify_delete
+ON chroma_core_alertstate;
+
+DROP FUNCTION IF EXISTS table_update_notify();
+""")


### PR DESCRIPTION
Add triggers for broadcasting Insert | Update | Delete changes on the
chroma_core_alertstate table.

This will use Postgres NOTIFY to send a comma separated list of
operation name and id.

We should be using `json_build_object` but that's not available till
postgres 9.3.

Building off of this, any process with a client connection can do a
`LISTEN table_update` and will be asynchronously notified of changes on
the table.

Signed-off-by: Joe Grund <joe.grund@intel.com>