### PR TITLE
HYD-6355 For testing purposes limit tests that are run

### DIFF
--- a/chroma-manager/tests/framework/utils/selective_auto_pass.sh
+++ b/chroma-manager/tests/framework/utils/selective_auto_pass.sh
@@ -6,6 +6,38 @@
 . chroma-manager/tests/framework/utils/fake_pass.sh
 
 check_for_autopass() {
+    # currently defined tests:
+    # integration-tests-shared-storage-configuration-with-simulator
+    # integration-tests-existing-filesystem-configuration
+    # integration-tests-shared-storage-configuration
+    # test-services
+    # upgrade-tests
+    # unit-tests
+    # vvvvvvvvvvv this should come from a pragma in the commit message
+    ALL_TESTS="integration-tests-existing-filesystem-configuration
+               integration-tests-shared-storage-configuration
+               integration-tests-shared-storage-configuration-with-simulator
+               test-services
+               unit-tests
+               upgrade-tests"
+    commit_message=$(git log -n 1)
+    TESTS_TO_RUN=$(echo "$commit_message" | sed -ne '/^ *Run-tests:/s/^ *Run-tests: *//p')
+    if [ -n "$TESTS_TO_RUN" ]; then
+        TESTS_TO_SKIP=$ALL_TESTS
+        for t in $TESTS_TO_RUN; do
+            TESTS_TO_SKIP=${TESTS_TO_SKIP/$t/}
+        done
+    else
+        TESTS_TO_SKIP=$(echo "$commit_message" | sed -ne '/^ *Skip-tests:/s/^ *Skip-tests: *//p')
+    fi
+    for t in $TESTS_TO_SKIP; do
+        if [[ $JOB_NAME == $t || $JOB_NAME == $t/* ]]; then
+            echo "skipping this test due to {Run|Skip}-tests pragma"
+            fake_test_pass "tests_skipped_because_commit_pragma" "$WORKSPACE/test_reports/" ${BUILD_NUMBER}
+            exit 1
+        fi
+    done
+
     tests_required_for_gui_bumps="chroma-tests-services"
 
     if [[ $BUILD_JOB_NAME = *-reviews ]] && gui_bump && [[ ! $tests_required_for_gui_bumps = $JOB_NAME ]]; then


### PR DESCRIPTION
It would be nice and resource friendly to be able to limit the tests we
run when trying to diagnose a problem.

Allow two commit message pragmas "Run-tests" and "Skip-tests" to specify
a list of tests to either run or skip.

 - enhance check_for_autopass() to look for a commit pragma and limit
   tests being run based on that
 - pass the tests that were skipped
 - reorder passes so that distribution support is before gui-bump

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>