### PR TITLE
HYD-7213 Exceptions found in agent logs for known conditions

### DIFF
--- a/chroma-agent/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_targets.py
@@ -115,7 +115,13 @@ def get_resource_locations():
     """Parse `crm_mon -1` to identify where (if anywhere)
        resources (i.e. targets) are running."""
 
-    rc, lines_text, stderr = AgentShell.run_old(["crm_mon", "-1", "-r"])
+    try:
+        rc, lines_text, stderr = AgentShell.run_old(["crm_mon", "-1", "-r"])
+    except OSError, e:
+        # ENOENT is fine here.  Pacemaker might not be installed yet.
+        if e.errno != errno.ENOENT:
+            raise
+
     if rc != 0:
         # Pacemaker not running, or no resources configured yet
         return {"crm_mon_error": {"rc": rc,


### PR DESCRIPTION
We should be able to rely on finding any exceptions in the chroma agent
logs as being indications of defects.  We have even periodically
discussed having the test framework fail tests if exceptions are found
in the agent log(s).

This unfortunately is not quite true (yet).

There are expected exceptions when the agent scan starts before
Pacemaker has been installed.  Rather than letting these pollute the
logs, we should catch them.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>