### PR TITLE
Use global locks to protect against zpool import-export sequence interruption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ deps: repo
 
 tags:
 	#find chroma-agent/chroma_agent chroma-manager/{tests,chroma_{agent_comms,api,cli,core,ui}} -type f | ctags -L -
-	ctags --python-kinds=-i -R --exclude=chroma-\*/myenv\* --exclude=chroma-dependencies --exclude=chroma_unit_test_env --exclude=chroma-externals --exclude=chroma-manager/chroma_ui* --exclude=chroma-manager/ui-modules .
+	ctags --python-kinds=-i -R --exclude=chroma-manager/_topdir --exclude=chroma-\*/myenv\* --exclude=chroma-dependencies --exclude=chroma_unit_test_env --exclude=chroma-externals --exclude=chroma-manager/ui-modules .
 
 # build the chroma-{agent,management} subdirs before the chroma-dependencies subdir
 chroma-dependencies: chroma-agent chroma-manager chroma-diagnostics

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ deps: repo
 
 tags:
 	#find chroma-agent/chroma_agent chroma-manager/{tests,chroma_{agent_comms,api,cli,core,ui}} -type f | ctags -L -
-	ctags --python-kinds=-i -R --exclude=chroma-manager/_topdir --exclude=chroma-\*/myenv\* --exclude=chroma-dependencies --exclude=chroma_unit_test_env --exclude=chroma-externals --exclude=chroma-manager/ui-modules .
+	ctags --python-kinds=-i -R --exclude=chroma-\*/myenv\* --exclude=chroma-dependencies --exclude=chroma_unit_test_env --exclude=chroma-externals --exclude=chroma-manager/chroma_ui* --exclude=chroma-manager/ui-modules .
 
 # build the chroma-{agent,management} subdirs before the chroma-dependencies subdir
 chroma-dependencies: chroma-agent chroma-manager chroma-diagnostics

--- a/chroma-agent/Target
+++ b/chroma-agent/Target
@@ -63,7 +63,7 @@ Target_start() {
     if Target_status >/dev/null 2>&1; then
         # ocf_log info "Target $TARGET is already started."
         dbg "Target $TARGET is already started."
-        return $OCF_SUCCESSs
+        return $OCF_SUCCESS
     fi
 
     if ! grep -e 'lustre$' /proc/filesystems >/dev/null; then

--- a/chroma-agent/Target
+++ b/chroma-agent/Target
@@ -53,37 +53,49 @@ The name of the target.
 END
 }
 
+dbg() {
+    echo "`date` RA $1" >> /var/log/chroma-agent.log
+}
+
 Target_start() {
+    dbg "Target_start()"
     # See if the device is already mounted.
     if Target_status >/dev/null 2>&1; then
-        ocf_log info "Target $TARGET is already started."
-        return $OCF_SUCCESS
+        # ocf_log info "Target $TARGET is already started."
+        dbg "Target $TARGET is already started."
+        return $OCF_SUCCESSs
     fi
 
     if ! grep -e 'lustre$' /proc/filesystems >/dev/null; then
-        ocf_log err "Couldn't find the lustre module in /proc/filesystems"
+        # ocf_log err "Couldn't find the lustre module in /proc/filesystems"
+        dbg "Couldn't find the lustre module in /proc/filesystems"
         return $OCF_ERR_ARGS
     fi
 
     # start the target
+    dbg "Starting: chroma-agent mount_target --uuid $TARGET --pacemaker_ha_operation 1"
     if ! chroma-agent mount_target --uuid $TARGET --pacemaker_ha_operation 1; then
-        ocf_log err "Couldn't start target $TARGET"
+        # ocf_log err "Couldn't start target $TARGET"
+        dbg "Couldn't start target $TARGET"
         return $OCF_ERR_GENERIC
     fi
     return $OCF_SUCCESS
 }
 
 Target_notify() {
+    dbg "Target_notify()"
     return $OCF_SUCCESS
 }
 
 Target_stop() {
+    dbg "Target_stop()"
     # started already?
     Target_status >/dev/null 2>&1
     if [ $? -eq $OCF_NOT_RUNNING ]; then
         # woo!  nothing to do.
         rc=$OCF_SUCCESS
     else
+        dbg "Unmounting: chroma-agent unmount_target --uuid $TARGET"
         chroma-agent unmount_target --uuid $TARGET
     fi
 
@@ -91,6 +103,7 @@ Target_stop() {
 }
 
 Target_status() {
+    dbg "Target_status()"
     # call the agent to see if it's running
     if chroma-agent target_running --uuid $TARGET >/dev/null 2>&1; then
         rc=$OCF_SUCCESS
@@ -101,14 +114,16 @@ Target_status() {
     fi
 
     if [ "$OP" = "status" ]; then
-        ocf_log info "$msg"
+        dbg "$msg"
+    #    ocf_log info "$msg"
     fi
 
     return $rc
 }
 
 Target_validate_all() {
-	return $OCF_SUCCESS
+    dbg "Target_validate_all()"
+    return $OCF_SUCCESS
 }
 
 if [ $# -ne 1 ]; then

--- a/chroma-agent/chroma_agent/action_plugins/manage_node.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_node.py
@@ -83,7 +83,7 @@ def initialise_block_device_drivers():
 def terminate_block_device_drivers():
     console_log.info("Terminating drivers for block device types")
     for cls in util.all_subclasses(BlockDevice):
-        error = cls.terminate_driver(config.profile_managed)
+        error = cls.terminate_driver()
 
         if error:
             return agent_error(error)

--- a/chroma-agent/chroma_agent/agent_daemon.py
+++ b/chroma-agent/chroma_agent/agent_daemon.py
@@ -29,6 +29,7 @@ from chroma_agent.plugin_manager import ActionPluginManager, DevicePluginManager
 from chroma_agent.agent_client import AgentClient
 from chroma_agent.log import daemon_log, daemon_log_setup, console_log_setup, increase_loglevel, decrease_loglevel
 from chroma_agent.lib.agent_startup_functions import agent_daemon_startup_functions
+from chroma_agent.lib.agent_teardown_functions import agent_daemon_teardown_functions
 
 
 class ServerProperties(object):
@@ -207,4 +208,9 @@ def main():
         # NB I would rather ensure cleanup by using 'with', but this
         # is python 2.4-compatible code
         context.close()
+
+    # Call any agent daemon startup methods that were registered.
+    for function in agent_daemon_teardown_functions:
+        function()
+
     daemon_log.info("Terminating")

--- a/chroma-agent/chroma_agent/agent_daemon.py
+++ b/chroma-agent/chroma_agent/agent_daemon.py
@@ -177,6 +177,7 @@ def main():
         def teardown_callback(*args, **kwargs):
             agent_client.stop()
             agent_client.join()
+            [function() for function in agent_daemon_teardown_functions]
 
         if not args.foreground:
             handlers = {
@@ -191,8 +192,7 @@ def main():
             signal.signal(signal.SIGUSR2, increase_loglevel)
 
         # Call any agent daemon startup methods that were registered.
-        for function in agent_daemon_startup_functions:
-            function()
+        [function() for function in agent_daemon_startup_functions]
 
         agent_client.start()
         # Waking-wait to pick up signals
@@ -209,8 +209,7 @@ def main():
         # is python 2.4-compatible code
         context.close()
 
-    # Call any agent daemon startup methods that were registered.
-    for function in agent_daemon_teardown_functions:
-        function()
+    # Call any agent daemon teardown methods that were registered.
+    [function() for function in agent_daemon_teardown_functions]
 
     daemon_log.info("Terminating")

--- a/chroma-agent/chroma_agent/lib/agent_teardown_functions.py
+++ b/chroma-agent/chroma_agent/lib/agent_teardown_functions.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2017 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a MIT-style
+# license that can be found in the LICENSE file.
+
+
+agent_daemon_teardown_functions = []
+
+
+def agent_daemon_teardown_function():
+    """
+    A decorator for connecting method to teardown. A method decorated with this will be called each time the
+    daemon is run. The call will occur just before the agent starts receiving commands from the manager.
+
+        @receiver(post_save, sender=MyModel)
+        def signal_receiver(sender, **kwargs):
+            ...
+
+    """
+    def _decorator(func):
+        agent_daemon_teardown_functions.append(func)
+        return func
+
+    return _decorator

--- a/chroma-agent/chroma_agent/lib/agent_teardown_functions.py
+++ b/chroma-agent/chroma_agent/lib/agent_teardown_functions.py
@@ -9,12 +9,7 @@ agent_daemon_teardown_functions = []
 def agent_daemon_teardown_function():
     """
     A decorator for connecting method to teardown. A method decorated with this will be called each time the
-    daemon is terminated normally. The call will occur just before the agent stops receiving commands from the manager.
-
-        @receiver(post_save, sender=MyModel)
-        def signal_receiver(sender, **kwargs):
-            ...
-
+    daemon is terminated normally.
     """
     def _decorator(func):
         agent_daemon_teardown_functions.append(func)

--- a/chroma-agent/chroma_agent/lib/agent_teardown_functions.py
+++ b/chroma-agent/chroma_agent/lib/agent_teardown_functions.py
@@ -9,7 +9,7 @@ agent_daemon_teardown_functions = []
 def agent_daemon_teardown_function():
     """
     A decorator for connecting method to teardown. A method decorated with this will be called each time the
-    daemon is run. The call will occur just before the agent starts receiving commands from the manager.
+    daemon is terminated normally. The call will occur just before the agent stops receiving commands from the manager.
 
         @receiver(post_save, sender=MyModel)
         def signal_receiver(sender, **kwargs):

--- a/chroma-agent/tests/actions_plugins/test_manage_target.py
+++ b/chroma-agent/tests/actions_plugins/test_manage_target.py
@@ -77,6 +77,14 @@ class TestFormatTarget(CommandCaptureTestCase):
     block_device_list = [BlockDevice('linux', '/dev/foo'),
                          BlockDevice('zfs', 'lustre1')]
 
+    def setUp(self):
+        super(TestFormatTarget, self).setUp()
+
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.lock_pool').start()
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.unlock_pool').start()
+
+        self.addCleanup(mock.patch.stopall)
+
     def _mkfs_path(self, block_device, target_name):
         """ The mkfs path could be different for different block_device types. Today it isn't but it was when this
         method was added and so rather than remove the method I've made it return the same value for both cases and
@@ -358,6 +366,12 @@ class TestXMLParsing(unittest.TestCase):
 
 
 class TestCheckBlockDevice(CommandCaptureTestCase):
+    def setUp(self):
+        super(TestCheckBlockDevice, self).setUp()
+
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.lock_pool').start()
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.unlock_pool').start()
+
     def test_occupied_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="ext4\n"))
 

--- a/chroma-agent/tests/chroma_common/blockdevices/test_blockdevice_zfs.py
+++ b/chroma-agent/tests/chroma_common/blockdevices/test_blockdevice_zfs.py
@@ -64,6 +64,9 @@ kernel modules are functioning properly.
     def setUp(self):
         super(TestBlockDeviceZFS, self).setUp()
 
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.lock_pool').start()
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.unlock_pool').start()
+        mock.patch('os.mkdir').start()
         self.patch_init_modules = mock.patch.object(BlockDeviceZfs, '_initialize_modules')
         self.patch_init_modules.start()
 

--- a/chroma-agent/tests/chroma_common/blockdevices/test_exported_zfs_device.py
+++ b/chroma-agent/tests/chroma_common/blockdevices/test_exported_zfs_device.py
@@ -1,13 +1,20 @@
-import time
-import threading
+import os
+import shutil
 import mock
-from collections import defaultdict
+import time
 
-from chroma_agent.chroma_common.blockdevices.blockdevice_zfs import ZfsDevice
+from collections import defaultdict
+from lockfile import LockFile
+
+
 from tests.command_capture_testcase import CommandCaptureCommand
 from tests.command_capture_testcase import CommandCaptureTestCase
+from chroma_agent.chroma_common.blockdevices.blockdevice_zfs import ZfsDevice
 from chroma_agent.chroma_common.lib.util import ExceptionThrowingThread
 from chroma_agent.chroma_common.lib.shell import BaseShell
+
+TEST_ZPOOL_LOCK_DIR = '/tmp/chroma-agent-test-locks'
+TEST_LOCK_ACQUIRE_TIMEOUT = 1
 
 
 class TestZfsDevice(CommandCaptureTestCase):
@@ -16,13 +23,7 @@ class TestZfsDevice(CommandCaptureTestCase):
 
         self.zpool_name = 'Dave'
 
-        # Reset the locks or 1 test failing kills all the other.s
-        ZfsDevice.import_locks = defaultdict(lambda: threading.RLock())
-
-        self.lock = ZfsDevice.import_locks[self.zpool_name]
-        self.thread_running = False
-
-        self.assertEqual(type(self.lock), threading._RLock)
+        self.addCleanup(mock.patch.stopall)
 
     def _add_import_commands(self, name='Boris'):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), stdout=name))
@@ -32,6 +33,48 @@ class TestZfsDevice(CommandCaptureTestCase):
 
     def _add_export_commands(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'export', self.zpool_name)))
+
+    @staticmethod
+    def _get_zfs_device(name, try_import):
+        device = ZfsDevice(name, try_import)
+        device.lock_unique_id = 'mockhost_mockthread.mockpid:%s' % name
+        return device
+
+
+class TestZfsDeviceImportExport(TestZfsDevice):
+    def setUp(self):
+        super(TestZfsDeviceImportExport, self).setUp()
+
+        class MockLockFile(LockFile):
+            # add attributes to mock that would be created at runtime and therefore cannot be autospecced
+            unique_name = None
+            pid = 12345
+
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.LockFile', autospec=MockLockFile).start()
+
+        ZfsDevice.lock_refcount = defaultdict(int)
+        self.zfs_device = ZfsDevice(self.zpool_name, False)
+        self.zfs_device.lock_unique_id = 'mockhost_mockthread.mockpid:%s' % self.zpool_name
+        self.zfs_device.lock.path = '%s/%s' % (ZfsDevice.ZPOOL_LOCK_DIR, self.zpool_name)
+        self.zfs_device.lock.reset_mock()
+
+        self.zfs_device.lock.acquire.return_value = None
+        self.zfs_device.lock.acquire.side_effect = self._toggle_lock
+        self.zfs_device.lock.release.return_value = None
+        self.zfs_device.lock.release.side_effect = self._toggle_lock
+        self.zfs_device.lock.is_locked.return_value = False
+        self.zfs_device.lock.i_am_locking.return_value = False
+
+    def _toggle_lock(self, timeout=0):
+        self.zfs_device.lock.i_am_locking.return_value ^= True
+        self.zfs_device.lock.is_locked.return_value ^= True
+
+    def _acquire_returns(self, timeout=0):
+        self.idx += 1
+        try:
+            raise self.acquire_actions[self.idx]
+        except TypeError:
+            self.acquire_actions[self.idx](self)
 
     def test_import(self):
         for force in [True, False]:
@@ -43,32 +86,77 @@ class TestZfsDevice(CommandCaptureTestCase):
                                                         (('-N', '-o', 'readonly=on', '-o', 'cachefile=none') if readonly else ()) +
                                                         (self.zpool_name,)))
 
-                ZfsDevice(self.zpool_name, False).import_(force, readonly)
+                self.zfs_device.import_(force, readonly)
+
+                self.zfs_device.lock.acquire.assert_called_once_with(ZfsDevice.LOCK_ACQUIRE_TIMEOUT)
+                self.zfs_device.lock.release.assert_called_once_with()
+                self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
 
                 self.assertRanAllCommandsInOrder()
+                self.zfs_device.lock.reset_mock()
+
+    # def test_import_locked(self):
+    #     self.reset_command_capture()
+    #
+    #     self.zfs_device.lock.acquire.side_effect = LockTimeout
+    #
+    #     with self.assertRaises(LockTimeout):
+    #         self.zfs_device.import_(False, False)
+    #
+    #     self.assertEqual(self.zfs_device.lock.acquire.call_count,
+    #                      (ZPOOL_LOCK_TIMEOUT / LOCK_ACQUIRE_TIMEOUT) + 1)
+    #
+    #     self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), None)
+    #     self.assertEqual(self.zfs_device.lock.release.call_count, 0)
+    #     self.assertEqual(self.zfs_device.lock.break_lock.call_count, 0)
+    #
+    #     self.assertRanAllCommandsInOrder()
+
+    # def test_import_force_locked(self):
+    #     self.reset_command_capture()
+    #
+    #     self.add_commands(CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o',
+    #                                              'cachefile=none', self.zpool_name,)))
+    #
+    #     # simulate 2 lock timeouts and then a successful lock acquire as side effects
+    #     self.idx = -1
+    #     self.acquire_actions = (LockTimeout, self._toggle_lock)
+    #     self.zfs_device.lock.acquire.side_effect = self._acquire_returns
+    #
+    #     self.zfs_device.import_(True, True, True)
+    #
+    #     delattr(self, 'acquire_actions')
+    #     delattr(self, 'idx')
+    #
+    #     self.zfs_device.lock.acquire.assert_has_calls([mock.call(LOCK_ACQUIRE_TIMEOUT),
+    #                                                    mock.call(LOCK_ACQUIRE_TIMEOUT)])
+    #
+    #     self.zfs_device.lock.break_lock.assert_called_once_with()
+    #     self.zfs_device.lock.release.assert_called_once_with()
+    #     self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
+    #
+    #     self.assertRanAllCommandsInOrder()
 
     def test_import_writable(self):
         self._add_import_commands()
         self._add_export_commands()
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        self.assertFalse(self.zfs_device.try_import)
+        self.zfs_device.try_import = True
 
-        self.assertEqual(exported_zfs_device.__enter__().available, True)
-        exported_zfs_device.__exit__(0, 0, 0)
+        self.assertTrue(self.zfs_device.__enter__().available)
 
-        self.assertRanAllCommandsInOrder()
+        self.assertTrue(self.zfs_device.lock.i_am_locking())
+        self.assertTrue(self.zfs_device.pool_imported)
+        self.assertTrue(self.zfs_device.available)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 1)
 
-    def test_simple_lock(self):
-        self._add_import_commands()
-        self._add_export_commands()
+        self.zfs_device.__exit__(0, 0, 0)
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
-
-        self.assertEqual(exported_zfs_device.__enter__().available, True)
-        self.assertEqual(self.lock._RLock__count, 1)
-
-        exported_zfs_device.__exit__(0, 0, 0)
-        self.assertEqual(self.lock._RLock__count, 0)
+        self.assertFalse(self.zfs_device.pool_imported)
+        self.assertFalse(self.zfs_device.lock.i_am_locking())
+        self.assertFalse(self.zfs_device.pool_imported)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
 
         self.assertRanAllCommandsInOrder()
 
@@ -77,127 +165,73 @@ class TestZfsDevice(CommandCaptureTestCase):
 
         for count in range(1, 10):
             self._add_import_commands()
-            exported_zfs_devices.insert(0, ZfsDevice(self.zpool_name, True))
+            exported_zfs_devices.insert(0, self._get_zfs_device(self.zpool_name, True))
             self.assertEqual(exported_zfs_devices[0].__enter__().available, True)
-            self.assertEqual(self.lock._RLock__count, count)
+            self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), count)
+            self.assertTrue(exported_zfs_devices[0].lock.i_am_locking())
+            self.assertTrue(exported_zfs_devices[0].pool_imported)
 
         for count in range(9, 0, -1):
             self._add_export_commands()
             exported_zfs_devices[0].__exit__(0, 0, 0)
+            self.assertFalse(exported_zfs_devices[0].pool_imported)
+            self.assertEqual(exported_zfs_devices[0].lock.i_am_locking(),
+                             True if ((count - 1) > 0) else False)
+            self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), count - 1)
             del exported_zfs_devices[0]
-            self.assertEqual(self.lock._RLock__count, count - 1)
 
-        self.assertEqual(self.lock._RLock__count, 0)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
+        self.assertFalse(ZfsDevice(self.zpool_name, True).lock.is_locked())
+
         self.assertRanAllCommandsInOrder()
 
     def test_simple_lock_no_import(self):
         self._add_import_commands(self.zpool_name)
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
 
         self.assertEqual(exported_zfs_device.__enter__().available, True)
-        self.assertEqual(self.lock._RLock__count, 1)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 1)
+        self.assertTrue(exported_zfs_device.lock.i_am_locking())
+        self.assertFalse(exported_zfs_device.pool_imported)
 
         exported_zfs_device.__exit__(0, 0, 0)
-        self.assertEqual(self.lock._RLock__count, 0)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
+        self.assertFalse(exported_zfs_device.lock.i_am_locking())
+        self.assertFalse(exported_zfs_device.pool_imported)
 
         self.assertRanAllCommandsInOrder()
-
-    def import_(self):
-        self.add_command(('zpool', 'import', self.zpool_name))
-        self.thread_running = True
-        ZfsDevice(self.zpool_name, True).import_(False, False)
-        self.thread_running = False
-
-    def export(self):
-        self._add_export_commands()
-        self.thread_running = True
-        ZfsDevice(self.zpool_name, True).export()
-        self.thread_running = False
-
-    def test_import_blocks(self):
-        self._add_import_commands()
-        self._add_export_commands()
-
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
-
-        self.assertEqual(exported_zfs_device.__enter__().available, True)
-        self.assertEqual(self.lock._RLock__count, 1)
-
-        # Now this thread should block.
-        thread = ExceptionThrowingThread(target=self.import_,
-                                         args=(),
-                                         use_threads=True)
-        thread.start()
-
-        time.sleep(0.1)
-        self.assertEqual(self.thread_running, True)
-        time.sleep(0.1)
-        self.assertEqual(self.thread_running, True)
-
-        exported_zfs_device.__exit__(0, 0, 0)
-
-        time.sleep(0.1)
-        self.assertEqual(self.thread_running, False)
-
-        self.assertEqual(self.lock._RLock__count, 0)
-
-        thread.join()
-
-    def test_export_blocks(self):
-        self._add_import_commands()
-        self._add_export_commands()
-
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
-
-        self.assertEqual(exported_zfs_device.__enter__().available, True)
-        self.assertEqual(self.lock._RLock__count, 1)
-
-        # Now this thread should block.
-        thread = ExceptionThrowingThread(target=self.export,
-                                         args=(),
-                                         use_threads=True)
-        thread.start()
-
-        time.sleep(0.1)
-        self.assertEqual(self.thread_running, True)
-        time.sleep(0.1)
-        self.assertEqual(self.thread_running, True)
-
-        exported_zfs_device.__exit__(0, 0, 0)
-
-        time.sleep(0.1)
-        self.assertEqual(self.thread_running, False)
-
-        self.assertEqual(self.lock._RLock__count, 0)
-
-        thread.join()
 
     def test_error_in_list(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), rc=1))
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
 
-        try:
-            self.assertEqual(exported_zfs_device.__enter__(), True)
-        except BaseShell.CommandExecutionError:
-            pass
+        with self.assertRaises(BaseShell.CommandExecutionError):
+            exported_zfs_device.__enter__()
 
-        self.assertEqual(self.lock._RLock__count, 0)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
+        self.assertFalse(exported_zfs_device.lock.i_am_locking())
+        self.assertFalse(exported_zfs_device.pool_imported)
+        self.assertFalse(exported_zfs_device.available)
+
+        self.assertRanAllCommandsInOrder()
 
     def test_error_in_import(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), stdout='Boris'),
-                          CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o', 'cachefile=none', self.zpool_name), rc=1))
+                          CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o', 'cachefile=none',
+                                                 self.zpool_name), rc=1))
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
 
-        self.assertEqual(exported_zfs_device.__enter__().available, False)
+        self.assertFalse(exported_zfs_device.__enter__().available)
 
-        self.assertEqual(self.lock._RLock__count, 1)
+        self.assertFalse(exported_zfs_device.pool_imported)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 1)
 
         exported_zfs_device.__exit__(0, 0, 0)
 
-        self.assertEqual(self.lock._RLock__count, 0)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
 
         self.assertRanAllCommandsInOrder()
 
@@ -205,18 +239,17 @@ class TestZfsDevice(CommandCaptureTestCase):
         self._add_import_commands()
         self.add_commands(CommandCaptureCommand(('zpool', 'export', self.zpool_name), rc=1))
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
 
-        self.assertEqual(exported_zfs_device.__enter__().available, True)
+        self.assertTrue(exported_zfs_device.__enter__().available)
 
-        self.assertEqual(self.lock._RLock__count, 1)
+        self.assertTrue(exported_zfs_device.pool_imported)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 1)
 
-        try:
+        with self.assertRaises(BaseShell.CommandExecutionError):
             exported_zfs_device.__exit__(0, 0, 0)
-        except BaseShell.CommandExecutionError:
-            pass
 
-        self.assertEqual(self.lock._RLock__count, 0)
+        self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
 
         self.assertRanAllCommandsInOrder()
 
@@ -230,7 +263,7 @@ class TestZfsDevice(CommandCaptureTestCase):
 
         mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.time.sleep').start()
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
 
         self.assertEqual(exported_zfs_device.__enter__().available, True)
         exported_zfs_device.__exit__(0, 0, 0)
@@ -246,20 +279,93 @@ class TestZfsDevice(CommandCaptureTestCase):
 
         mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.time.sleep').start()
 
-        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
 
         self.assertEqual(exported_zfs_device.__enter__().available, True)
 
-        try:
+        with self.assertRaises(BaseShell.CommandExecutionError):
             exported_zfs_device.__exit__(0, 0, 0)
-        except BaseShell.CommandExecutionError:
-            pass
 
-    def test_no_import_silient(self):
-        exported_zfs_device = ZfsDevice(self.zpool_name, False)
+    def test_no_import_silent(self):
+        exported_zfs_device = self._get_zfs_device(self.zpool_name, False)
 
         self.assertEqual(exported_zfs_device.available, True)
         self.assertEqual(exported_zfs_device.__enter__().available, True)
+        self.assertFalse(exported_zfs_device.pool_imported)
         exported_zfs_device.__exit__(0, 0, 0)
 
         self.assertRanAllCommandsInOrder()
+
+
+class TestZfsDeviceLockFile(TestZfsDevice):
+    def setUp(self):
+        super(TestZfsDeviceLockFile, self).setUp()
+
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.ZPOOL_LOCK_DIR',
+                   TEST_ZPOOL_LOCK_DIR).start()
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.LOCK_ACQUIRE_TIMEOUT',
+                   TEST_LOCK_ACQUIRE_TIMEOUT).start()
+
+        self.zpool_name = 'Dave'
+        self.thread_running = False
+
+        shutil.rmtree(ZfsDevice.ZPOOL_LOCK_DIR, ignore_errors=True)
+        os.mkdir(ZfsDevice.ZPOOL_LOCK_DIR)
+
+    def tearDown(self):
+        shutil.rmtree(ZfsDevice.ZPOOL_LOCK_DIR, ignore_errors=True)
+
+    def import_(self):
+        self.add_command(('zpool', 'import', self.zpool_name))
+        self.thread_running = True
+        zfs_device = ZfsDevice(self.zpool_name, False)
+        zfs_device.import_(False, False)
+        self.assertFalse(zfs_device.lock.i_am_locking())
+        self.thread_running = False
+
+    def export(self):
+        self._add_export_commands()
+        self.thread_running = True
+        ZfsDevice(self.zpool_name, False).export()
+        self.thread_running = False
+
+    def _blocking_test_base(self, target_func):
+        self._add_import_commands()
+        self._add_export_commands()
+
+        exported_zfs_device = ZfsDevice(self.zpool_name, True)
+        self.assertEqual(exported_zfs_device.lock_unique_id, '%s:%s' % (exported_zfs_device.lock.unique_name,
+                                                                        self.zpool_name))
+
+        self.assertTrue(exported_zfs_device.__enter__().available)
+        self.assertEqual(ZfsDevice.lock_refcount.get(exported_zfs_device.lock_unique_id), 1)
+        self.assertTrue(exported_zfs_device.lock.i_am_locking())
+        self.assertTrue(exported_zfs_device.pool_imported)
+
+        # Now this thread should block.
+        thread = ExceptionThrowingThread(target=target_func,
+                                         args=(),
+                                         use_threads=True)
+        thread.start()
+
+        time.sleep(0.1)
+        self.assertEqual(self.thread_running, True)
+        time.sleep(0.1)
+        self.assertEqual(self.thread_running, True)
+
+        self.assertEqual(ZfsDevice.lock_refcount.get(exported_zfs_device.lock_unique_id), 1)
+
+        exported_zfs_device.__exit__(0, 0, 0)
+        self.assertFalse(exported_zfs_device.lock.i_am_locking())
+        self.assertFalse(exported_zfs_device.pool_imported)
+
+        thread.join()
+
+        time.sleep(0.1)
+        self.assertEqual(self.thread_running, False)
+
+    def test_import_blocks(self):
+        self._blocking_test_base(self.import_)
+
+    def test_export_blocks(self):
+        self._blocking_test_base(self.export)

--- a/chroma-agent/tests/chroma_common/filesystems/test_filesystem_zfs.py
+++ b/chroma-agent/tests/chroma_common/filesystems/test_filesystem_zfs.py
@@ -15,6 +15,9 @@ class TestFileSystemZFS(CommandCaptureTestCase):
         self.type_prop_mock = mock.PropertyMock(return_value='zfs')
         mock.patch.object(BlockDeviceZfs, 'filesystem_type', self.type_prop_mock).start()
 
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.lock_pool').start()
+        mock.patch('chroma_agent.chroma_common.blockdevices.blockdevice_zfs.ZfsDevice.unlock_pool').start()
+
         self.patch_init_modules = mock.patch.object(FileSystemZfs, '_initialize_modules')
         self.patch_init_modules.start()
 

--- a/chroma-agent/tests/device_plugins/linux/test_zfs.py
+++ b/chroma-agent/tests/device_plugins/linux/test_zfs.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import patch, Mock
 
 from chroma_agent.device_plugins.linux import ZfsDevices
 from chroma_agent.device_plugins.linux_components.block_devices import BlockDevices
@@ -45,6 +45,8 @@ class TestZfs(LinuxAgentTests, CommandCaptureTestCase):
     @patch('logging.Logger.debug', mock_debug)
     @patch('chroma_agent.utils.BlkId', dict)
     @patch('chroma_agent.device_plugins.linux_components.block_devices.BlockDevices.find_block_devs', mock_empty_dict)
+    @patch('chroma_agent.device_plugins.linux_components.zfs.ZfsDevice.lock_pool', Mock())
+    @patch('chroma_agent.device_plugins.linux_components.zfs.ZfsDevice.unlock_pool', Mock())
     def _setup_zfs_devices(self):
         blockdevices = BlockDevices()
 

--- a/chroma-common/blockdevices/blockdevice.py
+++ b/chroma-common/blockdevices/blockdevice.py
@@ -99,6 +99,10 @@ class BlockDevice(object):
     def initialise_driver(cls, managed_mode):
         return None
 
+    @classmethod
+    def terminate_driver(cls, managed_mode):
+        return None
+
     @abc.abstractmethod
     def mgs_targets(self, log):
         """

--- a/chroma-common/blockdevices/blockdevice.py
+++ b/chroma-common/blockdevices/blockdevice.py
@@ -100,7 +100,7 @@ class BlockDevice(object):
         return None
 
     @classmethod
-    def terminate_driver(cls, managed_mode):
+    def terminate_driver(cls):
         return None
 
     @abc.abstractmethod

--- a/chroma-common/blockdevices/blockdevice_zfs.py
+++ b/chroma-common/blockdevices/blockdevice_zfs.py
@@ -5,13 +5,13 @@
 import os
 import errno
 import re
-import shutil
 import time
 
 from collections import defaultdict
 from lockfile import LockFile, LockTimeout
 from ..lib import shell
 from blockdevice import BlockDevice
+from ..lib.util import pid_exists
 
 
 class ZfsDevice(object):
@@ -27,8 +27,8 @@ class ZfsDevice(object):
     operate on the device as if it was locally active.
     """
 
-    ZPOOL_LOCK_DIR = '/var/lib/chroma/zfs_locks-%d' % os.getpid()
-    LOCK_ACQUIRE_TIMEOUT = 60
+    ZPOOL_LOCK_DIR = '/var/lib/chroma/zfs_locks'
+    LOCK_ACQUIRE_TIMEOUT = 10
 
     lock_refcount = defaultdict(int)
     locks_dir_initialized = False
@@ -91,16 +91,11 @@ class ZfsDevice(object):
         """
         Attempt to acquire a lock on a given zpool through a lockfile, increment the reference count each time
         this method is called, regardless of whether acquire is actually called. Keep trying until we know
-        we are locking the zpool. Reset refcount if i_am_locking returns False (current thread+process is not locking).
+        we are locking the zpool.
 
-        Lock acquire polls the timeout internally until LOCK_ACQUIRE_TIMEOUT is reached.
-
-        :param force: when set to True, if the lock cannot be acquired then force/break the lock
+        Lock acquire polls the timeout at intervals of LOCK_ACQUIRE_TIMEOUT.
         """
-
         if ZfsDevice.locks_dir_initialized == False:
-            shutil.rmtree(self.ZPOOL_LOCK_DIR, ignore_errors=True)
-
             # ensure lock directory exists
             try:
                 os.mkdir(self.ZPOOL_LOCK_DIR)
@@ -112,8 +107,19 @@ class ZfsDevice(object):
         while not self.lock.i_am_locking():
             try:
                 self.lock.acquire(self.LOCK_ACQUIRE_TIMEOUT)
+                with open(self.lock.lock_file, 'w') as f:
+                    f.writelines(str(self.lock.pid))
             except LockTimeout:
-                pass
+                # prune locks owned by non-existent processes
+                with open(self.lock.lock_file, 'r') as f:
+                    contents = f.readlines()
+
+                assert len(contents) == 1 and contents[0].isdigit(), \
+                    'unexpected contents of lockfile %s: %s' % (self.lock.lock_file, contents)
+
+                # validate pid holding lock exists
+                if not pid_exists(int(contents[0])):
+                    self.lock.break_lock()
 
         self.lock_refcount[self.lock_unique_id] += 1
 
@@ -432,7 +438,7 @@ class BlockDeviceZfs(BlockDevice):
                     result = self.import_(pacemaker_ha_operation)
 
                     if (result is None) and (self.zpool_properties(True).get('readonly') == 'on'):
-                        return 'zfs pool %s can only be imported readonly, is it in use?' % self._device_path 
+                        return 'zfs pool %s can only be imported readonly, is it in use?' % self._device_path
 
                 else:
                     # zpool is already imported and writable, nothing to do.

--- a/chroma-common/blockdevices/blockdevice_zfs.py
+++ b/chroma-common/blockdevices/blockdevice_zfs.py
@@ -14,13 +14,16 @@ from ..lib import shell
 from blockdevice import BlockDevice
 from ..lib.util import pid_exists
 
-log = logging.getLogger(__name__)
+try:
+    from chroma_agent.log import daemon_log as log
+except ImportError:
+    log = logging.getLogger(__name__)
 
-if not log.handlers:
-    handler = logging.FileHandler('/var/log/chroma-agent.log')
-    handler.setFormatter(logging.Formatter("[%(asctime)s: %(levelname)s/%(name)s] %(message)s"))
-    log.addHandler(handler)
-    log.setLevel(logging.DEBUG)
+    if not log.handlers:
+        handler = logging.FileHandler('blockdevice_zfs.log')
+        handler.setFormatter(logging.Formatter("[%(asctime)s: %(levelname)s/%(name)s] %(message)s"))
+        log.addHandler(handler)
+        log.setLevel(logging.DEBUG)
 
 
 def get_lockfile_pid(lockfile):

--- a/chroma-common/blockdevices/blockdevice_zfs.py
+++ b/chroma-common/blockdevices/blockdevice_zfs.py
@@ -5,11 +5,11 @@
 import os
 import errno
 import re
-import threading
+import shutil
 import time
 
 from collections import defaultdict
-
+from lockfile import LockFile, LockTimeout
 from ..lib import shell
 from blockdevice import BlockDevice
 
@@ -26,7 +26,12 @@ class ZfsDevice(object):
     to the machine. The code imports in read only mode and then exports the device whilst the enclosed code can then
     operate on the device as if it was locally active.
     """
-    import_locks = defaultdict(lambda: threading.RLock())
+
+    ZPOOL_LOCK_DIR = '/var/lib/chroma/zfs_locks-%d' % os.getpid()
+    LOCK_ACQUIRE_TIMEOUT = 60
+
+    lock_refcount = defaultdict(int)
+    locks_dir_initialized = False
 
     def __init__(self, device_path, try_import):
         """
@@ -35,6 +40,12 @@ class ZfsDevice(object):
         then the caller must deal with ensuring the device is accessible.
         """
         self.pool_path = device_path.split('/')[0]
+
+        # Scope of a single process
+        self.lock = LockFile('%s/%s' % (self.ZPOOL_LOCK_DIR, self.pool_path))
+
+        # unique identifier used as key for reference counting lock calls on pool/thread/process
+        self.lock_unique_id = '%s:%s' % (self.lock.unique_name, self.pool_path)
         self.pool_imported = False
         self.try_import = try_import
         self.available = not try_import         # If we are not going to try to import it, then presume it is available
@@ -57,7 +68,6 @@ class ZfsDevice(object):
                     self.pool_imported = (result is None)
                 except:
                     self.unlock_pool()
-                    # log.debug('ZfsDevice released lock on %s due to exception' % self.pool_path)
                     raise
 
             self.available = (result is None)
@@ -78,14 +88,44 @@ class ZfsDevice(object):
             self.unlock_pool()
 
     def lock_pool(self):
-        lock = self.import_locks[self.pool_path]
-        lock.acquire()
-        # log.debug('ZfsDevice acquired lock on %s' % self.pool_path)
+        """
+        Attempt to acquire a lock on a given zpool through a lockfile, increment the reference count each time
+        this method is called, regardless of whether acquire is actually called. Keep trying until we know
+        we are locking the zpool. Reset refcount if i_am_locking returns False (current thread+process is not locking).
+
+        Lock acquire polls the timeout internally until LOCK_ACQUIRE_TIMEOUT is reached.
+
+        :param force: when set to True, if the lock cannot be acquired then force/break the lock
+        """
+
+        if ZfsDevice.locks_dir_initialized == False:
+            shutil.rmtree(self.ZPOOL_LOCK_DIR, ignore_errors=True)
+
+            # ensure lock directory exists
+            try:
+                os.mkdir(self.ZPOOL_LOCK_DIR)
+            except OSError:
+                pass
+
+            ZfsDevice.locks_dir_initialized = True
+
+        while not self.lock.i_am_locking():
+            try:
+                self.lock.acquire(self.LOCK_ACQUIRE_TIMEOUT)
+            except LockTimeout:
+                pass
+
+        self.lock_refcount[self.lock_unique_id] += 1
 
     def unlock_pool(self):
-        lock = self.import_locks[self.pool_path]
-        lock.release()
-        # log.debug('ZfsDevice released lock on %s' % self.pool_path)
+        """
+        Release the held lock, should only be called when holding the lock. Decrement the reference count
+        each time this method is called and release when reference count is equal to one.
+        """
+        self.lock_refcount[self.lock_unique_id] -= 1
+
+        if self.lock_refcount[self.lock_unique_id] == 0:
+            self.lock.release()
 
     def import_(self, force, readonly):
         """

--- a/chroma-common/lib/util.py
+++ b/chroma-common/lib/util.py
@@ -12,6 +12,7 @@ import platform
 from collections import namedtuple
 from collections import MutableSequence
 import sys
+import signal
 
 
 def running_nose_tests():
@@ -278,7 +279,7 @@ def pid_exists(pid):
         raise ValueError('invalid PID 0')
 
     try:
-        os.kill(pid, 0)
+        os.kill(pid, signal.SIG_DFL)
     except OSError as err:
         if err.errno == errno.ESRCH:
             # ESRCH == No such process

--- a/chroma-common/lib/util.py
+++ b/chroma-common/lib/util.py
@@ -4,6 +4,7 @@
 
 
 import os
+import errno
 import time
 import itertools
 import threading
@@ -261,3 +262,33 @@ def human_to_bytes(value_str):
     index = conversion.index(value_str[-1:].lower())
 
     return int(value * (1024 ** index))
+
+
+def pid_exists(pid):
+    """ Check whether pid exists in the current process table. """
+    assert type(pid) is int, 'supplied pid must be a digit'
+
+    if pid < 0:
+        return False
+    if pid == 0:
+        # According to "man 2 kill" PID 0 refers to every process
+        # in the process group of the calling process.
+        # On certain systems 0 is a valid PID but we have no way
+        # to know that in a portable fashion.
+        raise ValueError('invalid PID 0')
+
+    try:
+        os.kill(pid, 0)
+    except OSError as err:
+        if err.errno == errno.ESRCH:
+            # ESRCH == No such process
+            return False
+        elif err.errno == errno.EPERM:
+            # EPERM clearly means there's a process to deny access to
+            return True
+        else:
+            # According to "man 2 kill" possible error values are
+            # (EINVAL, EPERM, ESRCH)
+            raise
+    else:
+        return True

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json
@@ -120,14 +120,14 @@
     ],
     "lustre_devices": [
         {"path_index": 0,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "zfs"},
         {"path_index": 1,
             "backend_filesystem": "linux"},
         {"path_index": 2,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "zfs"},
         {"path_index": 3,
             "backend_filesystem": "linux"},
         {"path_index": 4,
-            "backend_filesystem": "linux"}
+            "backend_filesystem": "zfs"}
     ]
 }

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
@@ -79,10 +79,12 @@ class TestFilesystemSameNameHYD832(ChromaIntegrationTestCase):
         # Filter out the paths by removing anything with a leading /.
         datasets = [dataset for dataset in datasets if dataset.startswith('/') is False]
 
+        self.remote_operations.stop_agents(s['address'] for s in self.TEST_SERVERS[:4])
         self.cleanup_zfs_pools(self.TEST_SERVERS[:4],
                                self.CZP_REMOVEDATASETS | self.CZP_EXPORTPOOLS,
                                datasets,
                                True)
+        self.remote_operations.start_agents(s['address'] for s in self.TEST_SERVERS[:4])
 
         # Our other FS should be untouched
         self.assertEqual(len(self.chroma_manager.get("/api/filesystem/").json['objects']), 1)


### PR DESCRIPTION
Thread locks protect different threads from listing, importing or exporting the same zpool that another thread is using. This mechanism is implemented in chroma-common/blockdevices/blockdevice_zfs.py file ZfsDevice class. This is effective in protecting zpool transitions between threads running code within the same process.

Zpools can be imported and exported from other processes (which don't have knowledge of thread level locks) and interrupt the import-export sequences of IML. In order to avoid these race conditions,
global/file locks should be implemented which provide protection from these interruptions effective between different processes, not just between threads in the same process.

Implementing these global locks within the IML code will not prevent other non-IML processes from performing imports and exports (which is beyond the remit of IML) but it will protect against situation where pacemaker calls chroma-agent from a different process than the chroma-agent daemon (and therefore not aware of any locks being held). In that situation, global locks set from IML code will be detectable by any process running on the same host.

In order to provide a mechanism of reusing locks if the owning process terminate whilst lockfiles exist, IML writes the PID of the running process to the lockfile. When an IML process attempts to acquire a lock and fails due to timeout, the lockfile PID written inside is compared to active system process PIDs and if not found the lock is broken and reacquired by the current process.

- create necessary temporary directory during ZfsDevice.init
- create lock object during ZfsDevice.init
- acquire and release lock file on lock_pool and unlock_pool respectively
- if lock cannot be acquired, verify owning PID is active and if not then break the lock, then keep trying with a timeout
- make locks reentrant by applying reference counting per thread and lock object combination, only unlock when reference count is 0, increment reference count after lock has been acquired or if thread is already locking
- update and improve relevant unit tests
- the robustness of the lock protection is improved by ensuring that lockfiles are removed in a best effort attempt when the process exits (daemon or cli agent)