### PR TITLE
Remove django-supervisor

### DIFF
--- a/chroma-manager/chroma_core/lib/service_config.py
+++ b/chroma-manager/chroma_core/lib/service_config.py
@@ -53,16 +53,7 @@ class SupervisorStatus(object):
     def __init__(self):
         username = None
         password = None
-
-        if settings.DEBUG:
-            # In development, use inet_http_server set up by django-supervisor
-            username = hashlib.md5(settings.SECRET_KEY).hexdigest()[:7]
-            password = hashlib.md5(username).hexdigest()
-
-            url = "http://localhost:9100/RPC2"
-        else:
-            # In production, use static inet_http_server settings
-            url = "http://localhost:9100/RPC2"
+        url = "http://localhost:9100/RPC2"
 
         self._xmlrpc = xmlrpclib.ServerProxy(
             'http://127.0.0.1',

--- a/chroma-manager/requirements.dev
+++ b/chroma-manager/requirements.dev
@@ -7,7 +7,6 @@
 behave>=1.1.0
 django-extensions
 django-nose==1.2
-django-supervisor==0.3.0
 fudge
 https://bitbucket.org/jordilin/alerta/downloads/log4tailer-3.0.9.tar.gz
 # for fence_apc

--- a/chroma-manager/settings.py
+++ b/chroma-manager/settings.py
@@ -137,7 +137,7 @@ INSTALLED_APPS = (
     'benchmark'
 )
 
-OPTIONAL_APPS = ['django_extensions', 'django_coverage', 'django_nose', 'djsupervisor']
+OPTIONAL_APPS = ['django_extensions', 'django_coverage', 'django_nose']
 for app in OPTIONAL_APPS:
     import imp
     try:


### PR DESCRIPTION
We have a dependency on django-supervisor at dev time. It has some quirks
that makes having it more difficult than not.

Particularly, it requires a username / pw combo to use, and there
is no way to disable it.

Ironically, we do not require a un/pw to access supervisor in production.
This means we have to write special auth code for development and then
make sure to ignore it in production.

  - Remove django-supervisor.

Signed-off-by: Joe Grund <joe.grund@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/91)
<!-- Reviewable:end -->
