### PR TITLE
Add supervisor-status dep on the manager.

### DIFF
--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -53,6 +53,7 @@ Requires: policycoreutils-python
 Requires: python2-gevent >= 1.0.1
 Requires: system-config-firewall-base
 Requires: nodejs >= 1:6.9.4-2
+Requires: supervisor-status
 Conflicts: chroma-agent
 Requires(post): selinux-policy-targeted
 Obsoletes: httpd


### PR DESCRIPTION
Now that we have a rpm for detecting supervisor status over unix domain socket, add it to the manager as a dependency.