### PR TITLE
Add support for API key auth

### DIFF
--- a/chroma-manager/chroma_api/authentication.py
+++ b/chroma-manager/chroma_api/authentication.py
@@ -5,10 +5,17 @@
 
 import settings
 
+from tastypie.http import HttpUnauthorized
+
 from tastypie.authentication import Authentication, ApiKeyAuthentication
 from tastypie.authorization import Authorization, DjangoAuthorization
 from django.utils.crypto import constant_time_compare
 
+
+def has_api_key(request):
+    result = ApiKeyAuthentication().is_authenticated(request)
+
+    return isinstance(result, HttpUnauthorized)
 
 class CsrfAuthentication(Authentication):
     """Tastypie authentication class for rejecting POSTs
@@ -30,7 +37,7 @@ class CsrfAuthentication(Authentication):
     """
     def is_authenticated(self, request, object=None):
         # Return early if there is a valid API key
-        if ApiKeyAuthentication().is_authenticated(request):
+        if has_api_key(request):
             return True
 
         if request.method != "POST":
@@ -50,7 +57,7 @@ class AnonymousAuthentication(CsrfAuthentication):
     logged-in users unless settings.ALLOW_ANONYMOUS_READ is true"""
     def is_authenticated(self, request, object=None):
         # Return early if there is a valid API key
-        if ApiKeyAuthentication().is_authenticated(request):
+        if has_api_key(request):
             return True
 
         # If any authentication in the class hierarchy refuses, we refuse

--- a/chroma-manager/chroma_api/authentication.py
+++ b/chroma-manager/chroma_api/authentication.py
@@ -15,7 +15,7 @@ from django.utils.crypto import constant_time_compare
 def has_api_key(request):
     result = ApiKeyAuthentication().is_authenticated(request)
 
-    return isinstance(result, HttpUnauthorized)
+    return not isinstance(result, HttpUnauthorized)
 
 class CsrfAuthentication(Authentication):
     """Tastypie authentication class for rejecting POSTs

--- a/chroma-manager/chroma_api/authentication.py
+++ b/chroma-manager/chroma_api/authentication.py
@@ -27,14 +27,10 @@ class CsrfAuthentication(Authentication):
     In principle you can argue that any CSRF attacks on JSON APIs are
     the browser's (read: end user's) fault, not ours.  In the wild, that
     is a very unhelpful attitude.
-
-    TODO: it is annoying for non-browser clients to have to jump through the
-    CSRF hoops.  We should check if someone is authenticating by key instead
-    of username/password, and if so avoid applying the CSRF check.
     """
     def is_authenticated(self, request, object=None):
         # Return early if there is a valid API key
-        if ApiKeyAuthentication().is_authenticated(request, object):
+        if ApiKeyAuthentication().is_authenticated(request):
             return True
 
         if request.method != "POST":
@@ -54,7 +50,7 @@ class AnonymousAuthentication(CsrfAuthentication):
     logged-in users unless settings.ALLOW_ANONYMOUS_READ is true"""
     def is_authenticated(self, request, object=None):
         # Return early if there is a valid API key
-        if ApiKeyAuthentication().is_authenticated(request, object):
+        if ApiKeyAuthentication().is_authenticated(request):
             return True
 
         # If any authentication in the class hierarchy refuses, we refuse

--- a/chroma-manager/chroma_core/lib/service_config.py
+++ b/chroma-manager/chroma_core/lib/service_config.py
@@ -29,6 +29,8 @@ from django.core.management import ManagementUtility
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 
+from tastypie.models import ApiKey
+
 from chroma_core.models.bundle import Bundle
 from chroma_core.services.http_agent.crypto import Crypto
 from chroma_core.models import ServerProfile, ServerProfilePackage, ServerProfileValidation
@@ -570,6 +572,17 @@ class ServiceConfig(CommandLine):
             log.info("User '%s' successfully created." % username)
         else:
             log.info("User accounts already created")
+
+        API_USERNAME = "api"
+
+        try:
+            User.objects.get(username=API_USERNAME)
+            log.info("API user already created")
+        except User.DoesNotExist:
+            api_user = User.objects.create_superuser(API_USERNAME, "", User.objects.make_random_password())
+            api_user.groups.add(Group.objects.get(name='superusers'))
+            ApiKey.objects.get_or_create(user=api_user)
+            log.info("API user created")
 
         return error
 


### PR DESCRIPTION
As we move towards a distributed model, we need a way to authenticate against the api besides username / password combo.

 We currently proxy the session forward when needed, but this is sub-optimal.

This change is sub-optimal as well IMO (we should be using some sort of API gateway for auth and not concern ourselves with it in this service), but it enables further changes.