### PR TITLE
Create Stored Procedure for retrieving the API un/key combo

### DIFF
--- a/chroma-manager/chroma_core/migrations/0033_api_key_procedure.py
+++ b/chroma-manager/chroma_core/migrations/0033_api_key_procedure.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        db.execute("""
+CREATE OR REPLACE FUNCTION api_key(
+    OUT username text,
+    OUT key text
+) AS
+$func$
+BEGIN
+    SELECT ta.key, au.username
+    INTO key, username
+    FROM auth_user as au
+    INNER JOIN tastypie_apikey as ta on au.id = ta.user_id 
+    WHERE au.username = 'api';
+END
+$func$ LANGUAGE plpgsql;
+        """)
+
+    def backwards(self, orm):
+        db.execute("DROP FUNCTION IF EXISTS api_key();")


### PR DESCRIPTION
#94 added support for API key auth. However to retrieve the key and username, each service would need to construct a custom query.

Instead of that, add a stored procedure where anyone who has db credentials can issue a call.

There is still somewhat of a barrier in that a user needs db credentials, but this lowers the bar until we have a shared settings
store over a key value structure.