### PR TITLE
Fix upgrade tests

### DIFF
--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
@@ -18,8 +18,8 @@ fi
 # for now at least, we need to disable epel before installing the upgrade-from version
 yum-config-manager --disable addon-epel\$(rpm --eval %rhel)-x86_64
 # and the IML and extras repos
-yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/repo/epel-7/managerforlustre-manager-for-lustre-epel-7.repo
-yum-config-manager --add-repo http://mirror.centos.org/centos/7/extras/x86_64/
+yum-config-manager --disable managerforlustre-manager-for-lustre
+yum-config-manager --disable mirror.centos.org_centos_7_extras_x86_64_
 
 if [ -f /etc/yum.repos.d/autotest.repo ]; then
     rm -f /etc/yum.repos.d/autotest.repo

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
@@ -17,6 +17,9 @@ yum-config-manager --enable  rhel-$(rpm --eval %rhel)-server-optional-rpms
 fi
 # for now at least, we need to disable epel before installing the upgrade-from version
 yum-config-manager --disable addon-epel\$(rpm --eval %rhel)-x86_64
+# and the IML and extras repos
+yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/repo/epel-7/managerforlustre-manager-for-lustre-epel-7.repo
+yum-config-manager --add-repo http://mirror.centos.org/centos/7/extras/x86_64/
 
 if [ -f /etc/yum.repos.d/autotest.repo ]; then
     rm -f /etc/yum.repos.d/autotest.repo

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
@@ -15,6 +15,9 @@ pdsh -l root -R ssh -S -w $(spacelist_to_commalist $CHROMA_MANAGER ${STORAGE_APP
 if $RHEL; then
 yum-config-manager --enable  rhel-$(rpm --eval %rhel)-server-optional-rpms
 fi
+# for now at least, we need to disable epel before installing the upgrade-from version
+yum-config-manager --disable addon-epel\$(rpm --eval %rhel)-x86_64
+
 if [ -f /etc/yum.repos.d/autotest.repo ]; then
     rm -f /etc/yum.repos.d/autotest.repo
 fi

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -24,6 +24,15 @@ python \"$CHROMA_DIR\"/chroma-manager/tests/integration/utils/chroma_log_collect
 
 $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
 
+# we can't currently upgrade a CentOS 7.3 node to RHEL 7.4 so just NOOP
+# out if that's the case we are testing
+# pity we have to wait for a provisioning to complete to bail out here
+if [ "$TEST_DISTRO_NAME" = "el" -a
+     $(ssh root@$TEST_RUNNER "lsb_release -i -s") =
+     RedHatEnterpriseServer ]; then
+    exit 0
+fi
+
 # see if this cures the 401 errors from jenkins
 eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CONFIG")
 ssh root@$TEST_RUNNER "exec 2>&1; set -e; set +x

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -24,6 +24,8 @@ python \"$CHROMA_DIR\"/chroma-manager/tests/integration/utils/chroma_log_collect
 
 $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
 
+eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CONFIG")
+
 # we can't currently upgrade a CentOS 7.3 node to RHEL 7.4 so just NOOP
 # out if that's the case we are testing
 # pity we have to wait for a provisioning to complete to bail out here
@@ -33,8 +35,6 @@ if [ "$TEST_DISTRO_NAME" = "el" -a
     exit 0
 fi
 
-# see if this cures the 401 errors from jenkins
-eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CONFIG")
 ssh root@$TEST_RUNNER "exec 2>&1; set -e; set +x
 sed -i -e 's/Aitahd9u/"$JENKINS_PULL"/g' /etc/yum.repos.d/autotest.repo"
 

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -30,8 +30,8 @@ eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CO
 # out if that's the case we are testing
 # pity we have to wait for a provisioning to complete to bail out here
 if [ "$TEST_DISTRO_NAME" = "el" -a
-     $(ssh root@$TEST_RUNNER "lsb_release -i -s") =
-     RedHatEnterpriseServer ]; then
+     $(ssh root@$TEST_RUNNER "lsb_release -i -s") = \
+     CentOS ]; then
     exit 0
 fi
 

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -29,7 +29,7 @@ eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CO
 # we can't currently upgrade a CentOS 7.3 node to RHEL 7.4 so just NOOP
 # out if that's the case we are testing
 # pity we have to wait for a provisioning to complete to bail out here
-if [ "$TEST_DISTRO_NAME" = "el" -a
+if [ "$TEST_DISTRO_NAME" = "el" -a                  \
      $(ssh root@$TEST_RUNNER "lsb_release -i -s") = \
      CentOS ]; then
     exit 0

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -32,6 +32,7 @@ eval $(python $CHROMA_DIR/chroma-manager/tests/utils/json_cfg2sh.py "$CLUSTER_CO
 if [ "$TEST_DISTRO_NAME" = "el" -a                  \
      $(ssh root@$TEST_RUNNER "lsb_release -i -s") = \
      CentOS ]; then
+    fake_test_pass "tests_skipped_because_RHEL_cant_upgrade_CentOS" "$WORKSPACE/test_reports/" ${BUILD_NUMBER}
     exit 0
 fi
 

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -136,7 +136,7 @@ fi
 # re-enable needed repos needed for the upgraded version
 pdsh -l root -R ssh -S -w $(spacelist_to_commalist $CHROMA_MANAGER ${STORAGE_APPLIANCES[@]} ${WORKERS[@]}) "exec 2>&1; set -xe
 yum-config-manager --enable addon-epel\$(rpm --eval %rhel)-x86_64
-yum-config-manager --ensable managerforlustre-manager-for-lustre
+yum-config-manager --enable managerforlustre-manager-for-lustre
 yum-config-manager --enable mirror.centos.org_centos_7_extras_x86_64_" | dshbak -c
 if [ ${PIPESTATUS[0]} != 0 ]; then
     exit 1

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -133,13 +133,22 @@ if ! upgrade_os $TEST_DISTRO_NAME $UPGRADE_DISTRO_VERSION $(spacelist_to_commali
     exit 1
 fi
 
+# re-enable needed repos needed for the upgraded version
+pdsh -l root -R ssh -S -w $(spacelist_to_commalist $CHROMA_MANAGER ${STORAGE_APPLIANCES[@]} ${WORKERS[@]}) "exec 2>&1; set -xe
+yum-config-manager --enable addon-epel\$(rpm --eval %rhel)-x86_64
+yum-config-manager --ensable managerforlustre-manager-for-lustre
+yum-config-manager --enable mirror.centos.org_centos_7_extras_x86_64_" | dshbak -c
+if [ ${PIPESTATUS[0]} != 0 ]; then
+    exit 1
+fi
+
 # Install and setup manager
 scp $ARCHIVE_NAME $CHROMA_DIR/chroma-manager/tests/utils/upgrade.exp root@$CHROMA_MANAGER:/tmp
 ssh root@$CHROMA_MANAGER "#don't do this, it hangs the ssh up, when used with expect, for some reason: exec 2>&1
 set -ex
 existing_IML_version=\$(rpm -q --qf \"%{VERSION}-%{RELEASE}\n\" chroma-manager)
 
-# Unpack the previous install into /tmp/$UPGRADE_INSTALL_DIR
+# Unpack the current install into /tmp/$UPGRADE_INSTALL_DIR
 cd /tmp
 mkdir $UPGRADE_INSTALL_DIR
 mv $ARCHIVE_NAME $UPGRADE_INSTALL_DIR/$ARCHIVE_NAME
@@ -175,14 +184,14 @@ done
 
 echo \"Now with EPEL disabled\"
 
+yum-config-manager --disable *[eE][pP][eE][lL]*
+yum clean all
+yum makecache
+
 if expect ../upgrade.exp; then
     echo \"Installation unexpectedly succeeded with EPEL disabled\"
     exit 1
 fi
-
-yum-config-manager --disable *[eE][pP][eE][lL]*
-yum clean all
-yum makecache
 
 echo \"Re-enabling EPEL to continue\"
 


### PR DESCRIPTION
Fix the upgrade tests.

Since the version we are upgrading from didn't want EPEL enabled,
disable it before trying to install it.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>