### PR TITLE
Add the rc to the assertion in _ssh_address

### DIFF
--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -462,7 +462,7 @@ class RealRemoteOperations(RemoteOperations):
 
         # Verify we recieved the correct exit status if one was specified.
         if expected_return_code is not None:
-            self._test_case.assertEqual(rc, expected_return_code, "stdout: '%s' stderr: '%s'" % (stdout, stderr))
+            self._test_case.assertEqual(rc, expected_return_code, "rc: %s stdout: '%s' stderr: '%s'" % (rc, stdout, stderr))
 
         return Shell.RunResult(rc, stdout, stderr, timeout=False)
 


### PR DESCRIPTION
If the rc != expected_return_code, it would be useful to know what it was.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Run-test: integration-tests-shared-storage-configuration