### PR TITLE
Bump tastypie to 0.9.16

### DIFF
--- a/chroma-dependencies/Makefile
+++ b/chroma-dependencies/Makefile
@@ -34,7 +34,7 @@ requirements::
 	echo "amqp==1.4.5";                                       \
 	echo "Django==1.4.5";                                     \
 	echo "django-picklefield==0.1.9";                         \
-	echo "django-tastypie==0.9.11";                           \
+	echo "django-tastypie==0.9.16";                           \
 	echo "dse==3.3.0";                                        \
 	echo "gevent==1.0.1";                                     \
 	echo "greenlet==0.4.2";                                   \

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -44,7 +44,7 @@ Requires: rabbitmq-server
 Requires: ntp
 Requires: Django >= 1.4, Django < 1.5
 Requires: Django-south >= 0.7.4
-Requires: django-tastypie = 0.9.11
+Requires: django-tastypie = 0.9.16
 Requires: django-picklefield
 Requires: chroma-manager-libs = %{version}-%{release}
 Requires: chroma-manager-cli = %{version}-%{release}

--- a/chroma-manager/chroma_api/alert.py
+++ b/chroma-manager/chroma_api/alert.py
@@ -21,7 +21,6 @@ from tastypie import http
 from tastypie.authorization import DjangoAuthorization
 from tastypie.validation import Validation
 from chroma_api.authentication import AnonymousAuthentication
-from chroma_api.authentication import PATCHSupportDjangoAuth
 from chroma_core.models.lnet_configuration import LNetOfflineAlert
 from chroma_api.chroma_model_resource import ChromaModelResource
 from chroma_api.chroma_common.lib import util
@@ -49,7 +48,8 @@ class AlertSubscriptionValidation(Validation):
 
 
 class AlertSubscriptionAuthorization(DjangoAuthorization):
-    def apply_limits(self, request, object_list):
+    def read_list(self, object_list, bundle):
+        request = bundle.request
         if request.method is None:
             # Internal request, it's all good.
             return object_list
@@ -98,8 +98,13 @@ class AlertTypeResource(Resource):
 
         return _fixup_alert_name(bundle.obj)
 
-    def get_resource_uri(self, bundle_or_obj):
+    def get_resource_uri(self, bundle_or_obj=None):
         from tastypie.bundle import Bundle
+
+        url_name = 'api_dispatch_list'
+
+        if bundle_or_obj is not None:
+            url_name = 'api_dispatch_detail'
 
         kwargs = {
             'resource_name': self._meta.resource_name,
@@ -108,20 +113,20 @@ class AlertTypeResource(Resource):
 
         if isinstance(bundle_or_obj, Bundle):
             kwargs['pk'] = bundle_or_obj.obj.id
-        else:
+        elif bundle_or_obj is not None:
             kwargs['pk'] = bundle_or_obj.id
 
-        return self._build_reverse_url("api_dispatch_detail", kwargs=kwargs)
+        return self._build_reverse_url(url_name, kwargs=kwargs)
 
     def get_object_list(self, request):
         return [ContentType.objects.get_for_model(cls)
                 for cls in AlertStateBase.subclasses()
                 if cls is not AlertState]
 
-    def obj_get_list(self, request=None, **kwargs):
-        return self.get_object_list(request)
+    def obj_get_list(self, bundle, **kwargs):
+        return self.get_object_list(bundle.request)
 
-    def obj_get(self, request=None, **kwargs):
+    def obj_get(self, bundle, **kwargs):
         return ContentType.objects.get(pk=kwargs['pk'])
 
     class Meta:
@@ -171,7 +176,7 @@ class AlertResource(LongPollingAPI, SeverityResource):
     def dispatch(self, request_type, request, **kwargs):
         return self.handle_long_polling_dispatch(request_type, request, **kwargs)
 
-    def override_urls(self):
+    def prepend_urls(self):
         return [
             url(r'^(?P<resource_name>%s)/dismiss_all%s$' % (self._meta.resource_name, trailing_slash()), self.wrap_view('dismiss_all'), name='api_alert_dismiss_all'),
         ]
@@ -245,7 +250,7 @@ class AlertResource(LongPollingAPI, SeverityResource):
                      'record_type': SeverityResource.ALL_FILTER_ENUMERATION}
 
         ordering = ['begin', 'end', 'active']
-        authorization = PATCHSupportDjangoAuth()
+        authorization = DjangoAuthorization()
         authentication = AnonymousAuthentication()
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get', 'patch', 'put']

--- a/chroma-manager/chroma_api/authentication.py
+++ b/chroma-manager/chroma_api/authentication.py
@@ -8,7 +8,7 @@ import settings
 from tastypie.http import HttpUnauthorized
 
 from tastypie.authentication import Authentication, ApiKeyAuthentication
-from tastypie.authorization import Authorization, DjangoAuthorization
+from tastypie.authorization import Authorization
 from django.utils.crypto import constant_time_compare
 
 
@@ -82,52 +82,3 @@ class PermissionAuthorization(Authorization):
 
     def is_authorized(self, request, object = None):
         return request.user.has_perm(self.perm_name)
-
-
-class PATCHSupportDjangoAuth(DjangoAuthorization):
-    """Fixing v0.9.11 tasypie's django auth not handling PATCH
-
-    This is an implementation of this fix:
-    https://github.com/toastdriven/django-tastypie/pull/345/files
-
-    When we rev tastypie to >0.9.11, we should try to run without this code.
-    There is test covering this to check.  See
-    chroma-manager/tests/unit/chroma_api/test_dismissed.py
-
-    The procedure to remove this code is simply to change PATCHSupportDjangoAuth
-    to DjangoAuthorization in the 3 resources that define it.  And run the tests.
-    See HYD-2354
-    """
-
-    def is_authorized(self, request, object=None):
-        # GET is always allowed
-        if request.method == 'GET':
-            return True
-
-        klass = self.resource_meta.object_class
-
-        # cannot check permissions if we don't know the model
-        if not klass or not getattr(klass, '_meta', None):
-            return True
-
-        permission_codes = {
-            'POST': '%s.add_%s',
-            'PUT': '%s.change_%s',
-            'PATCH': '%s.change_%s',
-            'DELETE': '%s.delete_%s',
-            }
-
-        # cannot map request method to permission code name
-        if request.method not in permission_codes:
-            return True
-
-        permission_code = permission_codes[request.method] % (
-            klass._meta.app_label,
-            klass._meta.module_name)
-
-        # user must be logged in to check permissions
-        # authentication backend must set request.user
-        if not hasattr(request, 'user'):
-            return False
-
-        return request.user.has_perm(permission_code)

--- a/chroma-manager/chroma_api/chroma_model_resource.py
+++ b/chroma-manager/chroma_api/chroma_model_resource.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
+from tastypie.exceptions import ImmediateHttpResponse
 from tastypie.resources import ModelResource
 from tastypie import fields
 
@@ -39,6 +40,24 @@ class ChromaModelResource(ModelResource):
 
         return data
 
+    def obj_update(self, bundle, **kwargs):
+        self.is_valid(bundle)
+
+        if bundle.errors:
+            raise ImmediateHttpResponse(
+                response=self.error_response(bundle.request, bundle.errors[self._meta.resource_name]))
+
+        return ModelResource.obj_update(self, bundle, **kwargs)
+    
+    def obj_create(self, bundle, **kwargs):
+        self.is_valid(bundle)
+
+        if bundle.errors:
+            raise ImmediateHttpResponse(
+                response=self.error_response(bundle.request, bundle.errors[self._meta.resource_name]))
+
+        return ModelResource.obj_create(self, bundle, **kwargs)
+
 # Add enumeration type to the fields
 base_apifield___init__ = fields.ApiField.__init__
 
@@ -51,9 +70,10 @@ def apifield___init__(self,
                       readonly=False,
                       unique=False,
                       help_text=None,
+                      use_in='all',
                       enumerations=None):
 
-    base_apifield___init__(self, attribute, default, null, blank, readonly, unique, help_text)
+    base_apifield___init__(self, attribute, default, null, blank, readonly, unique, help_text, use_in)
 
     self.enumerations = enumerations
 

--- a/chroma-manager/chroma_api/client_error.py
+++ b/chroma-manager/chroma_api/client_error.py
@@ -11,6 +11,7 @@ import httpagentparser
 from tastypie.resources import Resource
 from tastypie.authorization import Authorization
 
+from chroma_api.validation_utils import validate
 from chroma_api.authentication import CsrfAuthentication
 from chroma_core.services.log import custom_log_register
 
@@ -34,7 +35,7 @@ class ClientErrorResource(Resource):
         always_return_data = False
         object_class = dict  # Not used, but required
 
-    def get_resource_uri(self, bundle):
+    def get_resource_uri(self, bundle=None):
         return None  # not used, but required
 
     def _init_log(self):
@@ -50,7 +51,8 @@ class ClientErrorResource(Resource):
         log_path = os.path.join(settings.LOG_PATH, log_filename)
         self.logger = custom_log_register(__name__, log_path)
 
-    def obj_create(self, bundle, request=None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
 
         # Creating the log in here limits the log to being created only by the user that
         # ultimately wants to write to it.  Moving initialization of this log to __init__

--- a/chroma-manager/chroma_api/corosync.py
+++ b/chroma-manager/chroma_api/corosync.py
@@ -15,6 +15,7 @@ from chroma_core.services import log_register
 from chroma_api.utils import StatefulModelResource
 from chroma_api.utils import BulkResourceOperation
 from chroma_api.utils import dehydrate_command
+from chroma_api.validation_utils import validate
 from chroma_api.authentication import AnonymousAuthentication
 from chroma_api.urls import api
 
@@ -53,8 +54,10 @@ class CorosyncConfigurationResource(StatefulModelResource, BulkResourceOperation
                      'id': ['exact'],
                      'host__fqdn': ['exact', 'startswith']}
 
-    def obj_update(self, bundle, request = None, **kwargs):
-        super(CorosyncConfigurationResource, self).obj_update(bundle, request, **kwargs)
+    @validate
+    def obj_update(self, bundle, **kwargs):
+        request = bundle.request
+        super(CorosyncConfigurationResource, self).obj_update(bundle, **kwargs)
 
         def _update_corosync_configuration(self, corosync_configuration, request, **kwargs):
             network_interface_ids = [resolve(interwork_interface)[2]['pk'] for interwork_interface in corosync_configuration['network_interfaces']]

--- a/chroma-manager/chroma_api/filesystem.py
+++ b/chroma-manager/chroma_api/filesystem.py
@@ -19,6 +19,7 @@ from tastypie.validation import Validation
 from tastypie.authorization import DjangoAuthorization
 from chroma_api.authentication import AnonymousAuthentication
 from chroma_api.utils import custom_response, ConfParamResource, MetricResource, dehydrate_command
+from chroma_api.validation_utils import validate
 from chroma_core.lib import conf_param
 
 
@@ -386,7 +387,9 @@ class FilesystemResource(MetricResource, ConfParamResource):
         validation = FilesystemValidation()
         always_return_data = True
 
-    def obj_create(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
+        request = bundle.request
 
         filesystem_id, command_id = JobSchedulerClient.create_filesystem(bundle.data)
         filesystem = ManagedFilesystem.objects.get(pk = filesystem_id)

--- a/chroma-manager/chroma_api/ha_cluster.py
+++ b/chroma-manager/chroma_api/ha_cluster.py
@@ -21,8 +21,8 @@ class HaClusterResource(Resource):
     def get_object_list(self, request):
         return HaCluster.all_clusters()
 
-    def obj_get_list(self, request=None, **kwargs):
-        return self.get_object_list(request)
+    def obj_get_list(self, bundle, **kwargs):
+        return self.get_object_list(bundle.request)
 
     class Meta:
         resource_name = 'ha_cluster'

--- a/chroma-manager/chroma_api/help.py
+++ b/chroma-manager/chroma_api/help.py
@@ -36,7 +36,7 @@ class HelpResource(Resource):
         authorization = DjangoAuthorization()
         authentication = AnonymousAuthentication()
 
-    def override_urls(self):
+    def prepend_urls(self):
         from django.conf.urls import url
         return [
             url(r"^(?P<resource_name>%s)/conf_param/$" % self._meta.resource_name, self.wrap_view('conf_param_help'), name="api_conf_param_help"),

--- a/chroma-manager/chroma_api/host.py
+++ b/chroma-manager/chroma_api/host.py
@@ -9,6 +9,7 @@ from chroma_core.services.job_scheduler.job_scheduler_client import JobScheduler
 from chroma_core.services import log_register
 from tastypie.validation import Validation
 from tastypie.utils import dict_strip_unicode_keys
+from chroma_api.validation_utils import validate
 
 import json
 
@@ -138,7 +139,9 @@ class ClientMountResource(ChromaModelResource):
         return self.alter_detail_data_to_serialize(None, self.full_dehydrate(
                self.build_bundle(obj = client_mount))).data
 
-    def obj_create(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
+        request = bundle.request
         host = self.fields['host'].hydrate(bundle).obj
         filesystem = self.fields['filesystem'].hydrate(bundle).obj
         mountpoint = bundle.data['mountpoint']
@@ -246,16 +249,18 @@ class HostResource(MetricResource, StatefulModelResource, BulkResourceOperation,
 
         bundle = self.build_bundle(data=dict_strip_unicode_keys(deserialized), request=request)
 
-        self.obj_update(bundle, request, **kwargs)
+        self.obj_update(bundle, **kwargs)
 
-    def obj_update(self, bundle, request, **kwargs):
+    @validate
+    def obj_update(self, bundle, **kwargs):
 
         def _update_action(self, data, request, **kwargs):
             # For simplicity lets fake the kwargs if we can, this is for when we are working from objects
             if 'address' in data:
                 host = ManagedHost.objects.get(address = data['address'])
             elif 'pk' in kwargs:
-                host = self.cached_obj_get(request = request, **self.remove_api_resource_names(kwargs))
+                host = self.cached_obj_get(self.build_bundle(
+                    data=data, request=request), **self.remove_api_resource_names(kwargs))
             else:
                 return self.BulkActionResult(None, "Unable to decipher target host", None)
 
@@ -267,7 +272,7 @@ class HostResource(MetricResource, StatefulModelResource, BulkResourceOperation,
             else:
                 if 'pk' in kwargs:
                     try:
-                        super(HostResource, self).obj_update(self.build_bundle(data=data, request=request), request, **kwargs)
+                        super(HostResource, self).obj_update(self.build_bundle(data=data, request=request), **kwargs)
                         return self.BulkActionResult(None, "State data not present for host %s" % host, None)
                     except ImmediateHttpResponse as ihr:
                         if int(ihr.response.status_code / 100) == 2:
@@ -277,9 +282,11 @@ class HostResource(MetricResource, StatefulModelResource, BulkResourceOperation,
                 else:
                     return self.BulkActionResult(None, "Bulk setting of state not yet supported", None)
 
-        self._bulk_operation(_update_action, 'command_and_host', bundle, request, **kwargs)
+        self._bulk_operation(_update_action, 'command_and_host',
+                             bundle, bundle.request, **kwargs)
 
-    def obj_create(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
         # FIXME HYD-1657: we get errors back just fine when something goes wrong
         # during registration, but the UI tries to format backtraces into
         # a 'validation errors' dialog which is pretty ugly.
@@ -289,11 +296,13 @@ class HostResource(MetricResource, StatefulModelResource, BulkResourceOperation,
         def _update_action(self, data, request, **kwargs):
             return self._create_host(None, data, request)
 
-        self._bulk_operation(_update_action, 'command_and_host', bundle, request, **kwargs)
+        self._bulk_operation(_update_action, 'command_and_host',
+                             bundle, bundle.request, **kwargs)
 
     def _create_host(self, address, data, request):
         # Resolve a server profile URI to a record
-        profile = ServerProfileResource().get_via_uri(data['server_profile'])
+        profile = ServerProfileResource().get_via_uri(
+            data['server_profile'], request)
 
         host, command = JobSchedulerClient.create_host_ssh(server_profile=profile.name, **_host_params(data, address))
 
@@ -379,11 +388,13 @@ class HostTestResource(Resource, BulkResourceOperation):
         object_class = dict
         validation = HostTestValidation()
 
-    def obj_create(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
         def _test_host_contact(self, data, request, **kwargs):
             return self.BulkActionResult(dehydrate_command(JobSchedulerClient.test_host_contact(**_host_params(data))), None, None)
 
-        self._bulk_operation(_test_host_contact, 'command', bundle, request, **kwargs)
+        self._bulk_operation(_test_host_contact, 'command',
+                             bundle, bundle.request, **kwargs)
 
 
 class HostProfileResource(Resource, BulkResourceOperation):
@@ -398,7 +409,12 @@ class HostProfileResource(Resource, BulkResourceOperation):
         authorization = DjangoAuthorization()
         object_class = dict
 
-    def get_resource_uri(self, bundle_or_obj):
+    def get_resource_uri(self, bundle_or_obj=None):
+        url_name = 'api_dispatch_list'
+
+        if bundle_or_obj is not None:
+            url_name = 'api_dispatch_detail'
+
         kwargs = {
             'resource_name': self._meta.resource_name,
             'api_name': self._meta.api_name
@@ -406,12 +422,12 @@ class HostProfileResource(Resource, BulkResourceOperation):
 
         if isinstance(bundle_or_obj, Bundle):
             kwargs['pk'] = bundle_or_obj.obj.id
-        else:
+        elif bundle_or_obj is not None:
             kwargs['pk'] = bundle_or_obj.id
 
-        return self._build_reverse_url("api_dispatch_detail", kwargs=kwargs)
+        return self._build_reverse_url(url_name, kwargs=kwargs)
 
-    def full_dehydrate(self, bundle):
+    def full_dehydrate(self, bundle, for_list=False):
         return bundle.obj
 
     HostProfiles = namedtuple("HostProfiles", ["profiles", "valid"])
@@ -470,32 +486,36 @@ class HostProfileResource(Resource, BulkResourceOperation):
                 'profiles': host_profiles.profiles,
                 'resource_uri': self.get_resource_uri(host)}
 
-    def obj_get(self, request, pk=None):
+    def obj_get(self, bundle, pk=None):
         host = get_object_or_404(ManagedHost, pk=pk)
 
-        return self._host_profiles_object(host, request)
+        return self._host_profiles_object(host, bundle.request)
 
-    def obj_get_list(self, request):
-        ids = request.GET.getlist('id__in')
+    def obj_get_list(self, bundle):
+        ids = bundle.request.GET.getlist('id__in')
         filters = {'id__in': ids} if ids else {}
 
         result = []
 
         for host in ManagedHost.objects.filter(**filters):
-            result.append({'host_profiles': self._host_profiles_object(host, request),
+            result.append({'host_profiles': self._host_profiles_object(host, bundle.request),
                            "error": None,
                            "traceback": None})
 
         return result
 
-    def obj_create(self, bundle, request, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
         def _create_action(self, data, request, **kwargs):
             return self.BulkActionResult(self._set_profile(data['host'], data['profile']), None, None)
 
-        self._bulk_operation(_create_action, 'commands', bundle, request, **kwargs)
-
-    def obj_update(self, bundle, request, **kwargs):
+        self._bulk_operation(_create_action, 'commands',
+                             bundle, bundle.request, **kwargs)
+    
+    @validate                             
+    def obj_update(self, bundle, **kwargs):
         def _update_action(self, data, request, **kwargs):
             return self.BulkActionResult(self._set_profile(kwargs['pk'], data['profile']), None, None)
 
-        self._bulk_operation(_update_action, 'commands', bundle, request, **kwargs)
+        self._bulk_operation(_update_action, 'commands',
+                             bundle, bundle.request, **kwargs)

--- a/chroma-manager/chroma_api/job.py
+++ b/chroma-manager/chroma_api/job.py
@@ -15,6 +15,7 @@ from chroma_api.authentication import AnonymousAuthentication
 from chroma_core.models import Job, StateLock
 from chroma_core.services.job_scheduler.job_scheduler_client import JobSchedulerClient
 from chroma_api.chroma_model_resource import ChromaModelResource
+from chroma_api.validation_utils import validate
 
 
 class StateLockResource(Resource):
@@ -174,7 +175,8 @@ class JobResource(ChromaModelResource):
         always_return_data = True
         validation = JobValidation()
 
-    def obj_update(self, bundle, request, **kwargs):
+    @validate
+    def obj_update(self, bundle, **kwargs):
         job = Job.objects.get(pk = kwargs['pk'])
         new_state = bundle.data['state']
 

--- a/chroma-manager/chroma_api/lnet_configuration.py
+++ b/chroma-manager/chroma_api/lnet_configuration.py
@@ -15,6 +15,7 @@ from chroma_core.services.job_scheduler.job_scheduler_client import JobScheduler
 from chroma_core.services import log_register
 from chroma_api.utils import dehydrate_command
 from chroma_api.utils import custom_response, StatefulModelResource
+from chroma_api.validation_utils import validate
 from chroma_api.authentication import AnonymousAuthentication
 from chroma_core.models import Command
 from long_polling_api import LongPollingAPI
@@ -58,9 +59,10 @@ class LNetConfigurationResource(StatefulModelResource, LongPollingAPI):
     def dispatch(self, request_type, request, **kwargs):
         return self.handle_long_polling_dispatch(request_type, request, **kwargs)
 
-    def obj_update(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_update(self, bundle, **kwargs):
         if 'pk' in kwargs:
-            return super(LNetConfigurationResource, self).obj_update(bundle, request, **kwargs)
+            return super(LNetConfigurationResource, self).obj_update(bundle, **kwargs)
 
         lnet_configurations_data = bundle.data.get('objects', [bundle.data])
 
@@ -77,7 +79,7 @@ class LNetConfigurationResource(StatefulModelResource, LongPollingAPI):
         except ObjectDoesNotExist:
             command = None
 
-        raise custom_response(self, request, http.HttpAccepted,
+        raise custom_response(self, bundle.request, http.HttpAccepted,
                               {
                                   'command': dehydrate_command(command)
                               })

--- a/chroma-manager/chroma_api/log.py
+++ b/chroma-manager/chroma_api/log.py
@@ -20,7 +20,8 @@ class LogAuthorization(DjangoAuthorization):
     Only users in the superusers and filesystem_administrators groups are
     allowed to retrieve non-Lustre messages
     """
-    def apply_limits(self, request, object_list):
+    def read_list(self, object_list, bundle):
+        request = bundle.request
         if (request.user.is_authenticated() and
                 request.user.groups.filter(name__in=['filesystem_administrators', 'superusers']).exists()):
             return object_list

--- a/chroma-manager/chroma_api/power_control.py
+++ b/chroma-manager/chroma_api/power_control.py
@@ -61,7 +61,7 @@ class ResolvingFormValidation(FormValidation):
         """
         data = bundle.data
 
-        if not request:
+        if not bundle.request:
             raise RuntimeError("Must be used with an incoming request")
 
         # Ensure we get a bound Form, regardless of the state of the bundle.
@@ -84,7 +84,7 @@ class ResolvingFormValidation(FormValidation):
 
 
 class DeleteablePowerObjectResource(CustomModelResource):
-    def obj_delete(self, request=None, **kwargs):
+    def obj_delete(self, bundle, **kwargs):
         """
         A ORM-specific implementation of ``obj_delete``.
 
@@ -98,7 +98,7 @@ class DeleteablePowerObjectResource(CustomModelResource):
 
         if not hasattr(obj, 'delete'):
             try:
-                obj = self.obj_get(request, **kwargs)
+                obj = self.obj_get(bundle, **kwargs)
             except ObjectDoesNotExist:
                 raise NotFound("A model instance matching the provided arguments could not be found.")
 

--- a/chroma-manager/chroma_api/related_field.py
+++ b/chroma-manager/chroma_api/related_field.py
@@ -5,8 +5,7 @@
 
 from tastypie.fields import RelatedField
 
-
-def dehydrate_related(self, bundle, related_resource):
+def dehydrate_related(self, bundle, related_resource, for_list=True):
     """
     Based on the ``full_resource``, returns either the endpoint or the data
     from ``full_dehydrate`` for the related resource.
@@ -20,13 +19,15 @@ def dehydrate_related(self, bundle, related_resource):
 
     # Now normalize it to actually be a boolean.
     dehydrate = dehydrate_flag_value not in [False, 'false', 'False', 0, '0', None]
+    should_dehydrate_full_resource = self.should_full_dehydrate(bundle, for_list=for_list)
 
-    if not dehydrate:
-        # Be a good netizen.
-        return related_resource.get_resource_uri(bundle)
-    else:
+    if dehydrate or should_dehydrate_full_resource:
         # ZOMG extra data and big payloads.
-        bundle = related_resource.build_bundle(obj=related_resource.instance, request=bundle.request)
+        bundle = related_resource.build_bundle(
+            obj=related_resource.instance,
+            request=bundle.request,
+            objects_saved=bundle.objects_saved
+        )
 
         # We have to be careful of recursive expansions caused by users flags, so remove flag
         # before call but replace it afterwards.
@@ -40,6 +41,9 @@ def dehydrate_related(self, bundle, related_resource):
         bundle.request.GET = args_safe
 
         return result
+    else:
+        # Be a good netizen.
+        return related_resource.get_resource_uri(bundle)
 
 
 RelatedField.dehydrate_related = dehydrate_related

--- a/chroma-manager/chroma_api/related_field.py
+++ b/chroma-manager/chroma_api/related_field.py
@@ -15,35 +15,36 @@ def dehydrate_related(self, bundle, related_resource, for_list=True):
 
     dehydrate_flag_name = "dehydrate__" + self.instance_name
 
-    dehydrate_flag_value = bundle.request.GET.get(dehydrate_flag_name, self.full)
+    should_dehydrate_full_resource = self.should_full_dehydrate(bundle, for_list=for_list)
+
+    dehydrate_flag_value = bundle.request.GET.get(dehydrate_flag_name, should_dehydrate_full_resource)
 
     # Now normalize it to actually be a boolean.
     dehydrate = dehydrate_flag_value not in [False, 'false', 'False', 0, '0', None]
-    should_dehydrate_full_resource = self.should_full_dehydrate(bundle, for_list=for_list)
 
-    if dehydrate or should_dehydrate_full_resource:
-        # ZOMG extra data and big payloads.
-        bundle = related_resource.build_bundle(
-            obj=related_resource.instance,
-            request=bundle.request,
-            objects_saved=bundle.objects_saved
-        )
-
-        # We have to be careful of recursive expansions caused by users flags, so remove flag
-        # before call but replace it afterwards.
-        # You have to preserved the original and pop from the copy because the original is immutable.
-        args_safe = bundle.request.GET
-        bundle.request.GET = args_safe.copy()
-        bundle.request.GET.pop(dehydrate_flag_name, None)
-
-        result = related_resource.full_dehydrate(bundle)
-
-        bundle.request.GET = args_safe
-
-        return result
-    else:
+    if not dehydrate:
         # Be a good netizen.
         return related_resource.get_resource_uri(bundle)
+
+    # ZOMG extra data and big payloads.
+    bundle = related_resource.build_bundle(
+        obj=related_resource.instance,
+        request=bundle.request,
+        objects_saved=bundle.objects_saved
+    )
+
+    # We have to be careful of recursive expansions caused by users flags, so remove flag
+    # before call but replace it afterwards.
+    # You have to preserved the original and pop from the copy because the original is immutable.
+    args_safe = bundle.request.GET
+    bundle.request.GET = args_safe.copy()
+    bundle.request.GET.pop(dehydrate_flag_name, None)
+
+    result = related_resource.full_dehydrate(bundle)
+
+    bundle.request.GET = args_safe
+
+    return result
 
 
 RelatedField.dehydrate_related = dehydrate_related

--- a/chroma-manager/chroma_api/session.py
+++ b/chroma-manager/chroma_api/session.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 import django.contrib.auth as auth
 
 from chroma_api.authentication import CsrfAuthentication
+from chroma_api.validation_utils import validate
 from tastypie.authorization import Authorization
 from tastypie.resources import Resource
 from tastypie import fields
@@ -89,10 +90,12 @@ class SessionResource(Resource):
         resource_name = 'session'
         validation = SessionValidation()
 
-    def get_resource_uri(self, bundle):
-        return self.get_resource_list_uri()
+    def get_resource_uri(self, bundle=None, url_name=None):
+        return Resource.get_resource_uri(self)
 
-    def obj_create(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
+        request = bundle.request
         """Authenticate a session using username + password authentication"""
         username = bundle.data['username']
         password = bundle.data['password']

--- a/chroma-manager/chroma_api/storage_resource.py
+++ b/chroma-manager/chroma_api/storage_resource.py
@@ -16,6 +16,7 @@ from chroma_api.authentication import AnonymousAuthentication
 from tastypie import fields
 from chroma_core.lib.storage_plugin.query import ResourceQuery
 from chroma_api.utils import MetricResource
+from chroma_api.validation_utils import validate
 
 from tastypie.exceptions import NotFound, ImmediateHttpResponse
 from tastypie import http
@@ -23,6 +24,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from chroma_api.storage_resource_class import filter_class_ids
 from chroma_api.chroma_model_resource import ChromaModelResource
+
 
 from chroma_core.services.plugin_runner.scan_daemon_interface import ScanDaemonRpcInterface
 
@@ -120,13 +122,13 @@ class StorageResourceResource(MetricResource, ChromaModelResource):
 
         return [k.__name__ for k in find_bases(bundle.obj.resource_class.get_class())]
 
-    def obj_get_list(self, request = None, **kwargs):
+    def obj_get_list(self, bundle, **kwargs):
         """Override this to do sorting in a way that depends on kwargs (we need
         to know what kind of object is being listed in order to resolve the
         ordering attribute to a model, and apply_sorting's arguments don't
         give you kwargs)"""
-        objs = super(StorageResourceResource, self).obj_get_list(request, **kwargs)
-        objs = self._sort_by_attr(objs, request.GET, **kwargs)
+        objs = super(StorageResourceResource, self).obj_get_list(bundle, **kwargs)
+        objs = self._sort_by_attr(objs, bundle.request.GET, **kwargs)
         return objs
 
     def get_list(self, request, **kwargs):
@@ -270,16 +272,17 @@ class StorageResourceResource(MetricResource, ChromaModelResource):
         always_return_data = True
         validation = StorageResourceValidation()
 
-    def obj_delete(self, request = None, **kwargs):
+    def obj_delete(self, bundle, **kwargs):
         try:
-            obj = self.obj_get(request, **kwargs)
+            obj = self.obj_get(bundle, **kwargs)
         except ObjectDoesNotExist:
             raise NotFound("A model instance matching the provided arguments could not be found.")
 
         ScanDaemonRpcInterface().remove_resource(obj.id)
         raise ImmediateHttpResponse(http.HttpAccepted())
 
-    def obj_create(self, bundle, request = None, **kwargs):
+    @validate
+    def obj_create(self, bundle, **kwargs):
         # Note: not importing this at module scope so that this module can
         # be imported without loading plugins (useful at installation)
         from chroma_core.lib.storage_plugin.manager import storage_plugin_manager
@@ -302,8 +305,9 @@ class StorageResourceResource(MetricResource, ChromaModelResource):
 
         return bundle
 
-    def obj_update(self, bundle, request = None, **kwargs):
-        bundle.obj = self.cached_obj_get(request = request, **self.remove_api_resource_names(kwargs))
+    @validate
+    def obj_update(self, bundle, **kwargs):
+        bundle.obj = self.cached_obj_get(bundle, **self.remove_api_resource_names(kwargs))
 
         if 'alias' in bundle.data:
             # FIXME: sanitize input for alias (it gets echoed back as markup)
@@ -334,8 +338,8 @@ class StorageResourceResource(MetricResource, ChromaModelResource):
 
         return bundle
 
-    def override_urls(self):
+    def prepend_urls(self):
         from django.conf.urls import url
-        return super(StorageResourceResource, self).override_urls() + [
+        return super(StorageResourceResource, self).prepend_urls() + [
             url(r"^(?P<resource_name>%s)/(?P<plugin_name>\D\w+)/(?P<class_name>\D\w+)/$" % self._meta.resource_name, self.wrap_view('dispatch_list'), name="dispatch_list"),
         ]

--- a/chroma-manager/chroma_api/storage_resource_class.py
+++ b/chroma-manager/chroma_api/storage_resource_class.py
@@ -83,7 +83,7 @@ class StorageResourceClassResource(ChromaModelResource):
         detail_allowed_methods = ['get']
         ordering = ['class_name']
 
-    def override_urls(self):
+    def prepend_urls(self):
         from django.conf.urls.defaults import url
         return [
             url(r"^(?P<resource_name>%s)/(?P<storage_plugin__module_name>\w+)/(?P<class_name>\w+)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="dispatch_detail"),

--- a/chroma-manager/chroma_api/system_status.py
+++ b/chroma-manager/chroma_api/system_status.py
@@ -118,8 +118,8 @@ class SystemStatusResource(Resource):
         list_allowed_methods = ['get']
         detail_allowed_methods = []
 
-    def get_resource_uri(self, bundle):
-        return self.get_resource_list_uri()
+    def get_resource_uri(self, bundle=None, url_name=None):
+        return Resource.get_resource_uri(self)
 
     def dehydrate_rabbitmq(self, bundle):
         return bundle.obj.get_rabbitmq()

--- a/chroma-manager/chroma_api/volume.py
+++ b/chroma-manager/chroma_api/volume.py
@@ -12,6 +12,7 @@ from tastypie import fields
 from tastypie.authorization import DjangoAuthorization
 from chroma_api.authentication import AnonymousAuthentication
 from chroma_api.chroma_model_resource import ChromaModelResource
+from chroma_api.validation_utils import validate
 
 from django.shortcuts import get_object_or_404
 from django.db.models import Q
@@ -186,11 +187,12 @@ class VolumeResource(ChromaModelResource):
 
         return objects
 
-    def obj_update(self, bundle, request, **kwargs):
+    @validate
+    def obj_update(self, bundle, **kwargs):
         # FIXME: I'm not exactly sure how cached cached_object_get is -- should
         # we be explicitly getting a fresh one?  I'm just following what the ModelResource
         # obj_update does - jcs
-        bundle.obj = self.cached_obj_get(request = request, **self.remove_api_resource_names(kwargs))
+        bundle.obj = self.cached_obj_get(bundle, **self.remove_api_resource_names(kwargs))
         volume = bundle.data
 
         # Check that we're not trying to modify a Volume that is in

--- a/chroma-manager/chroma_core/management/__init__.py
+++ b/chroma-manager/chroma_core/management/__init__.py
@@ -45,7 +45,7 @@ def setup_groups(app, **kwargs):
 
         # Allow fs admins to dismiss alerts
         grant_write(fsadmin_group, chroma_core.models.AlertState)
-        for alert_klass in all_subclasses(chroma_core.models.AlertState):
+        for alert_klass in all_subclasses(chroma_core.models.AlertStateBase):
             grant_write(fsadmin_group, alert_klass)
 
         fsusers_group = auth.models.Group.objects.create(name = "filesystem_users")

--- a/chroma-manager/chroma_core/models/power_control.py
+++ b/chroma-manager/chroma_core/models/power_control.py
@@ -51,7 +51,6 @@ class DeletablePowerControlModel(models.Model):
         except socket.gaierror, e:
             raise ValidationError("Unable to resolve %s: %s" % (address, e))
 
-
 class PowerControlType(DeletablePowerControlModel):
     agent = models.CharField(null = False, blank = False, max_length = 255,
             choices = [(a, a) for a in settings.SUPPORTED_FENCE_AGENTS],

--- a/chroma-manager/chroma_core/models/sparse_model.py
+++ b/chroma-manager/chroma_core/models/sparse_model.py
@@ -118,12 +118,14 @@ class SparseModel(models.Model):
 
     @classmethod
     def __new__(cls, *args, **kwargs):
+        required_class = cls
+
         try:
             if kwargs != {}:
                 if 'record_type' not in kwargs:
                     kwargs['record_type'] = cls.__name__
                 required_class = getattr(chroma_core.models, kwargs['record_type'])
-            else:
+            elif len(args) > 1:
                 # The args will be in the order of the fields, but we add 1 because the cls is appended on the front.
                 record_type_index = [field.attname for field in cls._meta.fields].index('record_type') + 1
                 required_class = getattr(chroma_core.models, args[record_type_index])

--- a/chroma-manager/tests/framework/unit/jenkins_steps/main
+++ b/chroma-manager/tests/framework/unit/jenkins_steps/main
@@ -27,48 +27,6 @@ cd $CHROMA_DIR/chroma-manager
 make requirements
 pip install -r requirements.txt
 
-#
-# patch behave for https://github.com/behave/behave/issues/63 with https://github.com/jenisys/behave/commit/6fa47d414bf25a53121edeb7caebac4d9d1b5fb4.diff
-#
-# you'd think that site.getsitepackages() was the right way to do this,
-# right?  well, you'd be correct except that life in a virtualenv is not
-# quite like life outside of it.
-# https://github.com/pypa/virtualenv/issues/355
-python_version=$(python -c 'import platform; print ".".join(platform.python_version_tuple()[0:2])')
-pushd $WORKSPACE/chroma_test_env/lib/python$python_version/site-packages
-patch -R -p1 <<"EOF" || true
-diff --git a/behave/model.py b/behave/model.py
-index 1183e1b..371c8dd 100644
---- a/behave/model.py
-+++ b/behave/model.py
-@@ -372,6 +372,8 @@ class Scenario(TagStatement, Replayable)
-         self.steps = steps or []
- 
-         self.background = None
-+        self.stderr = None
-+        self.stderr = None
- 
-     def __repr__(self):
-         return '<Scenario "%s">' % self.name
-EOF
-patch -p1 <<"EOF" || true
-diff --git a/behave/model.py b/behave/model.py
-index 1183e1b..371c8dd 100644
---- a/behave/model.py
-+++ b/behave/model.py
-@@ -372,6 +372,8 @@ class Scenario(TagStatement, Replayable)
-         self.steps = steps or []
- 
-         self.background = None
-+        self.stderr = None
-+        self.stdout = None
- 
-     def __repr__(self):
-         return '<Scenario "%s">' % self.name
-EOF
-
-popd
-
 if $MEASURE_COVERAGE; then
   python manage.py test --with-xunit --xunit-file=$WORKSPACE/test_reports/chroma-manager-unit-test-results.xml --with-coverage tests/unit/ <<EOC
 yes

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_auth.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_auth.py
@@ -107,7 +107,7 @@ class TestAuthentication(ChromaIntegrationTestCase):
         user['password2'] = 'bar'
         user['old_password'] = 'foo'
         response = basic_user_requests.put(user['resource_uri'], user)
-        self.assertEqual(response.status_code, 202, response.content)
+        self.assertEqual(response.status_code, 200, response.content)
 
         # Log back in with my new password
         basic_user_requests = AuthorizedHttpRequests(basic_user['username'], user['password1'],

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_conf_params.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_conf_params.py
@@ -99,7 +99,7 @@ class TestConfParams(ChromaIntegrationTestCase):
         mgt_volume = volumes[0]
         mdt_volumes = [volumes[1]]
         ost_volumes = [volumes[2]]
-        filesystem_id = self.create_filesystem(self.hosts,
+        filesystem_id = str(self.create_filesystem(self.hosts,
                                                {'name': 'testfs',
                                                 'mgt': {'volume_id': mgt_volume['id']},
                                                 'mdts': [{
@@ -110,7 +110,7 @@ class TestConfParams(ChromaIntegrationTestCase):
                                                     'volume_id': v['id'],
                                                     'conf_params': {}
                                                 } for v in ost_volumes],
-                                                'conf_params': {}})
+                                                'conf_params': {}}))
 
         # Mount the filesystem
         response = self.chroma_manager.get(

--- a/chroma-manager/tests/unit/chroma_api/chroma_api_test_case.py
+++ b/chroma-manager/tests/unit/chroma_api/chroma_api_test_case.py
@@ -152,7 +152,7 @@ class ChromaApiTestCase(ResourceTestCase):
         from chroma_api.urls import api
         for name, resource in api._registry.items():
             if 'get' in resource._meta.list_allowed_methods:
-                list_uri = resource.get_resource_list_uri()
+                list_uri = resource.get_resource_uri()
                 response = self.api_client.get(list_uri, data = {'limit': 0})
                 self.assertEqual(response.status_code, 200, "%s: %s %s" % (list_uri, response.status_code, self.deserialize(response)))
                 if 'get' in resource._meta.detail_allowed_methods:

--- a/chroma-manager/tests/unit/chroma_api/tastypie_test.py
+++ b/chroma-manager/tests/unit/chroma_api/tastypie_test.py
@@ -151,7 +151,7 @@ class ResourceTestCase(IMLUnitTestCase):
         """
         Ensures the response is returning either a HTTP 202 or a HTTP 204.
         """
-        return self.assertTrue(resp.status_code in [202, 204], resp.content)
+        return self.assertTrue(resp.status_code in [202, 204], "Expected 202 or 204 status code, got %s" % resp.status_code)
 
     def assertHttpNoContent(self, resp):
         """

--- a/chroma-manager/tests/unit/chroma_api/test_chroma_validation.py
+++ b/chroma-manager/tests/unit/chroma_api/test_chroma_validation.py
@@ -16,7 +16,7 @@ class MockResource(object):
     Meta.object_class = Meta
 
     @classmethod
-    def get_via_uri(cls, uri):
+    def get_via_uri(cls, uri, request=None):
         if uri == 'valid':
             return uri
         else:

--- a/chroma-manager/tests/unit/chroma_api/test_client_management.py
+++ b/chroma-manager/tests/unit/chroma_api/test_client_management.py
@@ -27,7 +27,7 @@ class LustreClientMountTests(ChromaApiTestCase):
 
         # Make sure it was created and that we can see it via API
         self.assertEqual(self.api_get("/api/client_mount/%s/" % mount.id)['id'],
-                         str(mount.id))
+                         mount.id)
 
         job = RemoveHostJob(host = self.host)
 
@@ -49,7 +49,7 @@ class LustreClientMountTests(ChromaApiTestCase):
 
         # Make sure it was created and that we can see it via API
         self.assertEqual(self.api_get("/api/client_mount/%s/" % mount.id)['id'],
-                         str(mount.id))
+                         mount.id)
 
         job = ForceRemoveHostJob(host = self.host)
 

--- a/chroma-manager/tests/unit/chroma_api/test_dismissed.py
+++ b/chroma-manager/tests/unit/chroma_api/test_dismissed.py
@@ -194,15 +194,7 @@ class TestFSAdminsCanDismiss(NotificationTestCase):
 
 
 class TestFSUsersCannotDismiss(NotificationTestCase):
-    """Make sure filesystem_users cannot Dismiss or Dismiss all alerts
-
-    This test characterizes a bug in django-tastypie v0.9.11.
-    See HYD-2339 for details.
-
-    When we decided to update tastypie, we can disable
-    the fix for this, and run this test to too verify is unnecessary.
-    See HYD-2354
-    """
+    """Make sure filesystem_users cannot Dismiss or Dismiss all alerts"""
 
     def __init__(self, methodName=None):
         super(TestFSUsersCannotDismiss, self).__init__(

--- a/chroma-manager/tests/unit/chroma_api/test_power_control.py
+++ b/chroma-manager/tests/unit/chroma_api/test_power_control.py
@@ -154,7 +154,7 @@ class PowerControlResourceTests(PowerControlResourceTestCase):
         new_values['address'] = '127.0.0.2'
         new_values['port'] = '4242'
 
-        # Tastypie 0.9.11 doesn't like nested PUTs with full resources
+        # Tastypie 0.9.16 doesn't like nested PUTs with full resources
         pdu['device_type'] = pdu['device_type']['resource_uri']
         pdu['outlets'] = [o['resource_uri'] for o in pdu['outlets']]
 
@@ -182,6 +182,7 @@ class PowerControlResourceTests(PowerControlResourceTestCase):
         with self.assertRaisesRegexp(AssertionError, "Unable to resolve"):
             kwargs = {'device_type': self.pdu_type['resource_uri'],
                       'address': 'localtoast'}
+
             self._create_power_device(**kwargs)
 
     def test_dupe_sockaddr_raises_useful_error(self):
@@ -293,7 +294,7 @@ class IpmiResourceTests(PowerControlResourceTestCase):
         outlet = pdu['outlets'][0]
         outlet['host'] = self.host['resource_uri']
         r = self.api_client.put(outlet['resource_uri'], data = outlet)
-        self.assertHttpAccepted(r)
+        self.assertHttpOK(r)
 
         with self.assertRaises(AssertionError):
             self._create_power_outlet(host = self.host['resource_uri'],

--- a/chroma-manager/tests/unit/chroma_api/test_registration_token.py
+++ b/chroma-manager/tests/unit/chroma_api/test_registration_token.py
@@ -157,7 +157,7 @@ class TestTokenAuthorization(ChromaApiTestCase):
             if row_count:
                 self.assertHttpOK(response)
             else:
-                self.assertHttpNotFound(response)
+                self.assertHttpUnauthorized(response)
 
     def test_patch(self):
         """Test that normal users cannot patch"""
@@ -178,4 +178,4 @@ class TestTokenAuthorization(ChromaApiTestCase):
             if allowed:
                 self.assertHttpAccepted(patch_response)
             else:
-                self.assertHttpNotFound(patch_response)
+                self.assertHttpUnauthorized(patch_response)

--- a/chroma-manager/tests/unit/chroma_api/test_related.py
+++ b/chroma-manager/tests/unit/chroma_api/test_related.py
@@ -12,13 +12,13 @@ class TestRelated(TestCase):
         self.mock_bundle = mock.Mock()
         self.mock_related_bundle = mock.Mock()
 
-        self.mock_related_field.should_full_dehydrate = mock.Mock(return_value=False)
+        self.mock_related_field.should_full_dehydrate = mock.Mock()
         self.mock_related_resource.build_bundle = mock.Mock(return_value=self.mock_related_bundle)
 
 
     def test_related_optional_expanded(self):
         ''' Test that an optional expand overrides a default full of false in dehydrate_related '''
-        self.mock_related_field.full = False
+        self.mock_related_field.should_full_dehydrate.return_value = False
         self.mock_related_field.instance_name = 'test_resource'
 
         self.mock_bundle.request.GET = {'dehydrate__test_resource': True}
@@ -37,7 +37,7 @@ class TestRelated(TestCase):
 
     def test_related_default_expanded(self):
         ''' Test that an default full of False works in dehydrate_related '''
-        self.mock_related_field.full = True
+        self.mock_related_field.should_full_dehydrate.return_value = True
         self.mock_related_field.instance_name = 'test_resource'
 
         self.mock_bundle.request.GET = {}
@@ -57,7 +57,7 @@ class TestRelated(TestCase):
     def test_related_optional_unexpanded(self):
         ''' Test that an optional no expand overrides a default full of true in dehydrate_related '''
 
-        self.mock_related_field.full = True
+        self.mock_related_field.should_full_dehydrate.return_value = True
         self.mock_related_field.instance_name = 'test_resource'
 
         for false_ in [False, 'false', 'False', 0, '0', None]:
@@ -79,7 +79,7 @@ class TestRelated(TestCase):
     def test_related_default_unexpanded(self):
         ''' Test that an default full of False works in dehydrate_related '''
 
-        self.mock_related_field.full = False
+        self.mock_related_field.should_full_dehydrate.return_value = False
         self.mock_related_field.instance_name = 'test_resource'
 
         self.mock_bundle.request.GET = {}

--- a/chroma-manager/tests/unit/chroma_api/test_related.py
+++ b/chroma-manager/tests/unit/chroma_api/test_related.py
@@ -12,7 +12,9 @@ class TestRelated(TestCase):
         self.mock_bundle = mock.Mock()
         self.mock_related_bundle = mock.Mock()
 
+        self.mock_related_field.should_full_dehydrate = mock.Mock(return_value=False)
         self.mock_related_resource.build_bundle = mock.Mock(return_value=self.mock_related_bundle)
+
 
     def test_related_optional_expanded(self):
         ''' Test that an optional expand overrides a default full of false in dehydrate_related '''
@@ -27,7 +29,8 @@ class TestRelated(TestCase):
                           self.mock_related_resource)
 
         self.mock_related_resource.build_bundle.assert_called_once_with(obj=self.mock_related_resource.instance,
-                                                                        request=self.mock_bundle.request)
+                                                                        request=self.mock_bundle.request,
+                                                                        objects_saved=self.mock_bundle.objects_saved)
         self.mock_related_resource.full_dehydrate.assert_called_once_with(self.mock_related_bundle)
         self.assertEqual(self.mock_related_resource.get_resource_uri.call_count, 0)
         self.assertEqual(self.mock_related_bundle.request.GET, {'dehydrate__test_resource': True})
@@ -45,13 +48,14 @@ class TestRelated(TestCase):
                           self.mock_related_resource)
 
         self.mock_related_resource.build_bundle.assert_called_once_with(obj=self.mock_related_resource.instance,
-                                                                        request=self.mock_bundle.request)
+                                                                        request=self.mock_bundle.request,
+                                                                        objects_saved=self.mock_bundle.objects_saved)
         self.mock_related_resource.full_dehydrate.assert_called_once_with(self.mock_related_bundle)
         self.assertEqual(self.mock_related_resource.get_resource_uri.call_count, 0)
         self.assertEqual(self.mock_related_bundle.request.GET, {})
 
     def test_related_optional_unexpanded(self):
-        ''' Test that an optional n0expand overrides a default full of true in dehydrate_related '''
+        ''' Test that an optional no expand overrides a default full of true in dehydrate_related '''
 
         self.mock_related_field.full = True
         self.mock_related_field.instance_name = 'test_resource'

--- a/chroma-manager/tests/unit/chroma_api/test_storage_resource.py
+++ b/chroma-manager/tests/unit/chroma_api/test_storage_resource.py
@@ -27,7 +27,6 @@ class TestStorageResourceResource(ChromaApiTestCase):
 
     def test_alias_put(self):
         """Check that the 'alias' attribute is validated as non-blank during PUTs"""
-
         response = self.api_client.post("/api/storage_resource/", data = {
             'plugin_name': 'loadable_plugin',
             'class_name': 'TestScannableResource',
@@ -42,7 +41,7 @@ class TestStorageResourceResource(ChromaApiTestCase):
         response = self.api_client.put(resource['resource_uri'], data = {
             'alias': valid_alias
         })
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
         response = self.api_client.get(resource['resource_uri'])
         self.assertEqual(self.deserialize(response)['alias'], valid_alias)
 

--- a/chroma-manager/tests/unit/chroma_api/test_user.py
+++ b/chroma-manager/tests/unit/chroma_api/test_user.py
@@ -17,7 +17,7 @@ class TestUserResource(ChromaApiTestCase):
 
         me['old_password'] = "lustre"
         response = self.api_client.put("/api/user/%s/" % me['id'], data = me)
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
 
     def test_HYD995_superuser_muggle(self):
         """Superuser changing normal user's password -- old_password not required"""
@@ -28,7 +28,7 @@ class TestUserResource(ChromaApiTestCase):
         muggle_data['new_password1'] = "newpwd"
         muggle_data['new_password2'] = "newpwd"
         response = self.api_client.put(muggle_data['resource_uri'], data = muggle_data)
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
 
     def test_HYD995_muggle_self(self):
         """Normal user changing his own password -- old_password required"""
@@ -48,7 +48,7 @@ class TestUserResource(ChromaApiTestCase):
 
         me['old_password'] = "muggle123"
         response = self.api_client.put("/api/user/%s/" % me['id'], data = me)
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
 
     def test_user_details_update(self):
         """Users should be able to update their details (first/last, email)"""
@@ -69,7 +69,7 @@ class TestUserResource(ChromaApiTestCase):
         me['last_name'] = "Josephson"
         me['email'] = "joebob@joebob.rocks"
         response = self.api_client.put("/api/user/%s/" % me['id'], data = me)
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
 
         me = self.deserialize(self.api_client.get("/api/session/"))['user']
         self.assertEqual(int(me['id']), int(joebob.id))
@@ -83,7 +83,7 @@ class TestUserResource(ChromaApiTestCase):
         superuser['accepted_eula'] = True
 
         response = self.api_client.put("/api/user/%s/" % superuser["id"], data=superuser)
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
 
         superuser = self.deserialize(self.api_client.get("/api/session/"))['user']
         self.assertTrue(superuser['accepted_eula'])
@@ -115,7 +115,7 @@ class TestUserResource(ChromaApiTestCase):
         superuser["is_superuser"] = False
 
         response = self.api_client.put("/api/user/%s/" % superuser["id"], data=superuser)
-        self.assertHttpAccepted(response)
+        self.assertHttpOK(response)
 
         superuser = self.deserialize(self.api_client.get("/api/session/"))['user']
         self.assertTrue(superuser['is_superuser'])
@@ -144,7 +144,7 @@ class TestUserResource(ChromaApiTestCase):
         me["accepted_eula"] = True
 
         resp = self.api_client.put("/api/user/%s/" % me["id"], data=me)
-        self.assertHttpAccepted(resp)
+        self.assertHttpOK(resp)
 
         me = self.deserialize(self.api_client.get("/api/session/"))['user']
         self.assertFalse(me["accepted_eula"])


### PR DESCRIPTION
0.9.11 only has options to do API key auth
with a querystring for GET.

0.9.12 has revamped auth code, and allows credentials to be sent via header as they should be.
However 0.9.12 has some other bugs, so we will bump to 0.9.16.

Even though this is listed as a patch change in semver, there are multiple api breaking changes.

They include:

  - `USE_TZ` is enforced at the API level, as a consequence tz's are dropped by default.
  - apply_limits is now a noop
  - `request` has been removed as a distinct param in many methods.
    We need to use `bundle.request` instead.
  - `override_urls` is deprecated, use prepend_urls instead.
  - Validation is moved later in the cycle. In addition, bundles
    are mutated at that point, meaning we need to restore
    earlier validation behavior.
  - PUTs now return a 200 instead of a 202 when returning data back.
  - Django auth limits seem to be verified now, where before they did not
    appear to be.
    An example is permissions missing for changing alerts, but users
    being allowed to dismiss anyway.

In addition to all of that, also removed some dead code that was trying to patch behave, but wouldn't apply.