### PR TITLE
Temporarily disable test_create_filesystem_with_failover_oss

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
@@ -97,6 +97,7 @@ class TestManagedFilesystemWithFailover(FailoverTestCaseMixin, StatsTestCaseMixi
                 volumes_expected_hosts_in_normal_state
             )
 
+    @skip('Disabled until LU-9725 is fixed')
     def test_create_filesystem_with_failover_oss(self):
 
         filesystem_id, volumes_expected_hosts_in_normal_state = self._test_create_filesystem_with_failover()

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
@@ -1,5 +1,6 @@
 
 
+from django.utils.unittest import skip
 from testconfig import config
 from tests.integration.core.chroma_integration_testcase import ChromaIntegrationTestCase
 from tests.integration.core.failover_testcase_mixin import FailoverTestCaseMixin


### PR DESCRIPTION
Temporarily Disable `test_create_filesystem_with_failover_oss` until
LU-9725 is fixed upstream.

I have added to #128 to track re-enabling this test once upstream bug
is fixed and verfied.