### PR TITLE
Pass NOSE_ARGS through from caller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,5 +119,6 @@ install_production: reset_cluster
 
 # To run a specific test:
 # make TESTS=tests/integration/shared_storage_configuration/test_example_api_client.py:TestExampleApiClient.test_login ssi_tests
+# set NOSE_ARGS="-x" to stop on the first failure
 ssi_tests: reset_cluster
 	chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/run_tests
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/run_tests
@@ -32,6 +32,7 @@ repoquery -q epel-release | grep epel-release || {
 echo "Begin running tests..."
 
 ssh root@$TEST_RUNNER "exec 2>&1; set -xe
+export NOSE_ARGS=\"$NOSE_ARGS\"
 cd /usr/share/chroma-manager/
 unset http_proxy; unset https_proxy
 ./tests/integration/run_tests -f -c /root/cluster_cfg.json -x ~/test_report.xml $TESTS || true"


### PR DESCRIPTION
Particularly in the case of running "make ssi_tests", if the caller
has $NOSE_ARGS set, pass those through to SSI's run_tests.

Such as:

$ NOSE_ARGS="-x" make ssi_tests

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>