### PR TITLE
Make sure parent classes are sorted in a stable way.

### DIFF
--- a/chroma-manager/chroma_api/storage_resource.py
+++ b/chroma-manager/chroma_api/storage_resource.py
@@ -120,7 +120,7 @@ class StorageResourceResource(MetricResource, ChromaModelResource):
 
             return bases
 
-        return [k.__name__ for k in find_bases(bundle.obj.resource_class.get_class())]
+        return [k.__name__ for k in find_bases(bundle.obj.resource_class.get_class())].sort()
 
     def obj_get_list(self, bundle, **kwargs):
         """Override this to do sorting in a way that depends on kwargs (we need


### PR DESCRIPTION
The realtime service relies on value equality of JSON objects to only emit changes downstream.

dehydration of parent classes was non-deterministic (order changed between requests).

This caused the realtime service to emit changes continually as subsequent JSON objects were not stable.

This patch makes the return call in the API consistent.