### PR TITLE
print statement syntax fails intermittently in behave tests

### DIFF
--- a/chroma-manager/tests/feature/cli/features/steps/standard_cli.py
+++ b/chroma-manager/tests/feature/cli/features/steps/standard_cli.py
@@ -91,5 +91,5 @@ def step(context, message):
         ok_(message not in "".join(context.stdout.readlines()))
     except AssertionError:
         context.stdout.seek(0)
-        print context.stdout.readlines()
+        print(context.stdout.readlines())
         raise


### PR DESCRIPTION
behave tests intermittently fail due to a strange Syntax error within error handling code

fix is to change the print statement to a print function