### PR TITLE
test_long_polling_locks fails due to exceeded timeout

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_long_polling.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_long_polling.py
@@ -4,6 +4,7 @@ import logging
 from tests.integration.core.long_polling_testing import LongPollingThread
 from tests.integration.core.chroma_integration_testcase import ChromaIntegrationTestCase
 from tests.chroma_common.lib.util import ExceptionThrowingThread
+from tests.integration.core.constants import LONG_TEST_TIMEOUT
 
 logger = logging.getLogger('test')
 logger.setLevel(logging.DEBUG)
@@ -190,7 +191,7 @@ class TestLongPollingLocks(LongPollingTestCase):
         self.long_polling_end_point.join()
 
         # Ensure update command completes before we exit the test
-        self.wait_for_command(self.chroma_manager, response.json['id'])
+        self.wait_for_command(self.chroma_manager, response.json['id'], timeout=LONG_TEST_TIMEOUT)
 
         # The locks should be the only change, and hence the thing that triggered the update
         original_host = self.long_polling_end_point.responses[0].json['objects'][0]


### PR DESCRIPTION
Timeout is exceeded but we can see the command complaints shortly after

example: http://jenkins.lotus.hpdd.lab.intel.com/job/integration-tests-shared-storage-configuration/777/arch=x86_64,distro=el7//consoleFull

this is an intermittent failure in SSI tests on 4.0.0