### PR TITLE
Pin {python-,}iml-common to ensure breaking changes are avoided as per semver

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -28,7 +28,7 @@ Requires: python2-tablib
 Requires: yum-utils
 Requires: initscripts
 Requires: chroma-diagnostics >= %{version}
-Requires: python2-iml-common
+Requires: python2-iml-common >= 1.0.0, python2-iml-common < 1.1.0
 %if 0%{?rhel} > 5
 Requires: util-linux-ng
 %endif

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -113,7 +113,7 @@ This is the Intel Manager for Lustre Monitoring and Administration Interface
 %package libs
 Summary: Common libraries for Chroma Server
 Group: System/Libraries
-Requires: python2-iml-common
+Requires: python2-iml-common >= 1.0.0, python2-iml-common < 1.1.0
 %description libs
 This package contains libraries for Chroma CLI and Chroma Server.
 
@@ -128,7 +128,8 @@ or on a separate node.
 %package integration-tests
 Summary: Intel Manager for Lustre Integration Tests
 Group: Development/Tools
-Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-django python-ordereddict python2-iml-common
+Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-django python-ordereddict
+Requires: python2-iml-common >= 1.0.0, python2-iml-common < 1.1.0
 %description integration-tests
 This package contains the Intel Manager for Lustre integration tests and scripts and is intended
 to be used by the Chroma test framework.

--- a/chroma-manager/requirements.dev
+++ b/chroma-manager/requirements.dev
@@ -18,4 +18,4 @@ pyflakes
 pygraphviz
 sphinx==1.1.3
 werkzeug
-iml-common
+iml-common>=1.0,<1.1


### PR DESCRIPTION
Currently in manifests, dependency on iml-common will always install latest, in order to manage upgrades, we want to observe semver and only install versions that match the minor version of the package (but can have different patch versions) as changes to the minor version number indicate API backwards incompatible changes which could well break application.