### PR TITLE
Add PostFormatCheck step to FormatTargetJob

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -28,7 +28,7 @@ Requires: python2-tablib
 Requires: yum-utils
 Requires: initscripts
 Requires: chroma-diagnostics >= %{version}
-Requires: python2-iml-common
+Requires: python2-iml-common >= 1.1.0, python2-iml-common < 1.2.0
 %if 0%{?rhel} > 5
 Requires: util-linux-ng
 %endif

--- a/chroma-agent/chroma_agent/action_plugins/agent_updates.py
+++ b/chroma-agent/chroma_agent/action_plugins/agent_updates.py
@@ -179,7 +179,7 @@ def kernel_status():
                                                     "kmod-lustre-client"]).split('\n')
                      if "kernel >=" in k).split(" >= ")[1]
             required_kernel = AgentShell.try_run(["rpm", "-q", "kernel-%s*" %
-                                                  required_kernel_prefix ]).split('\n')[0]
+                                                  required_kernel_prefix]).split('\n')[0]
         except (AgentShell.CommandExecutionError, StopIteration):
             required_kernel = None
     else:

--- a/chroma-agent/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_targets.py
@@ -177,7 +177,7 @@ def check_block_device(path, device_type):
     :param device_type: The type of device the path references
     :return The filesystem type of the filesystem on the device, or None if unoccupied.
     """
-    return agent_ok_or_error(BlockDevice(device_type, path).filesystem_info)
+    return agent_result(BlockDevice(device_type, path).filesystem_type)
 
 
 def format_target(device_type, target_name, device, backfstype,

--- a/chroma-agent/tests/actions_plugins/test_manage_target.py
+++ b/chroma-agent/tests/actions_plugins/test_manage_target.py
@@ -375,37 +375,51 @@ class TestCheckBlockDevice(CommandCaptureTestCase, AgentUnitTestCase):
     def test_occupied_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="ext4\n"))
 
-        self.assertAgentError(manage_targets.check_block_device("/dev/sdb", "linux"), "Filesystem found: type 'ext4'")
+        result = manage_targets.check_block_device('/dev/sdb', 'linux')
+        self.assertEqual(result['result'], 'ext4')
         self.assertRanAllCommands()
 
     def test_mbr_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), stdout="\n"))
 
-        self.assertAgentOK(manage_targets.check_block_device("/dev/sdb", "linux"))
+        result = manage_targets.check_block_device('/dev/sdb', 'linux')
+        self.assertEqual(result['result'], None)
         self.assertRanAllCommands()
 
     def test_empty_device_ldiskfs(self):
         self.add_commands(CommandCaptureCommand(("blkid", "-p", "-o", "value", "-s", "TYPE", "/dev/sdb"), rc=2))
 
-        self.assertAgentOK(manage_targets.check_block_device("/dev/sdb", "linux"))
+        result = manage_targets.check_block_device('/dev/sdb', 'linux')
+        self.assertEqual(result['result'], None)
         self.assertRanAllCommands()
 
     def test_occupied_device_zfs(self):
         self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\npool1/dataset_1\n")
 
-        self.assertAgentError(manage_targets.check_block_device("pool1", "zfs"),
-                              "Dataset 'dataset_1' found on zpool 'pool1'")
+        result = manage_targets.check_block_device("pool1", "zfs")
+        self.assertEqual(result['result'], 'zfs')
         self.assertRanAllCommands()
 
     def test_empty_device_zfs(self):
         self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\n")
 
-        self.assertAgentOK(manage_targets.check_block_device("pool1", "zfs"))
+        result = manage_targets.check_block_device("pool1", "zfs")
+        self.assertEqual(result['result'], None)
         self.assertRanAllCommands()
 
-    @unittest.skip('Unimplemented, need to test running check_block_device on a zfs dataset')
     def test_dataset_device_zfs(self):
-        pass
+        self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\npool1/dataset_1\n")
+
+        result = manage_targets.check_block_device("pool1/dataset_1", "zfs")
+        self.assertEqual(result['result'], 'zfs')
+        self.assertRanAllCommands()
+
+    def test_nonexistent_dataset_device_zfs(self):
+        self.add_command(("zfs", "list", "-H", "-o", "name", "-r", "pool1"), stdout="pool1\n")
+
+        result = manage_targets.check_block_device("pool1/dataset_1", "zfs")
+        self.assertEqual(result['result'], None)
+        self.assertRanAllCommands()
 
 
 class TestCheckImportExport(CommandCaptureTestCase, AgentUnitTestCase):

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -113,7 +113,7 @@ This is the Intel Manager for Lustre Monitoring and Administration Interface
 %package libs
 Summary: Common libraries for Chroma Server
 Group: System/Libraries
-Requires: python2-iml-common
+Requires: python2-iml-common >= 1.1.0, python2-iml-common < 1.2.0
 %description libs
 This package contains libraries for Chroma CLI and Chroma Server.
 
@@ -128,7 +128,8 @@ or on a separate node.
 %package integration-tests
 Summary: Intel Manager for Lustre Integration Tests
 Group: Development/Tools
-Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-django python-ordereddict python2-iml-common
+Requires: python-requests >= 2.6.0 python-nose python-nose-testconfig python-paramiko python-django python-ordereddict
+Requires: python2-iml-common >= 1.1.0, python2-iml-common < 1.2.0
 %description integration-tests
 This package contains the Intel Manager for Lustre integration tests and scripts and is intended
 to be used by the Chroma test framework.

--- a/chroma-manager/chroma_api/host.py
+++ b/chroma-manager/chroma_api/host.py
@@ -511,8 +511,8 @@ class HostProfileResource(Resource, BulkResourceOperation):
 
         self._bulk_operation(_create_action, 'commands',
                              bundle, bundle.request, **kwargs)
-    
-    @validate                             
+
+    @validate
     def obj_update(self, bundle, **kwargs):
         def _update_action(self, data, request, **kwargs):
             return self.BulkActionResult(self._set_profile(kwargs['pk'], data['profile']), None, None)

--- a/chroma-manager/chroma_api/utils.py
+++ b/chroma-manager/chroma_api/utils.py
@@ -653,6 +653,7 @@ class BulkResourceOperation(object):
 
     BulkActionResult = namedtuple('BulkActionResult', ['object', 'error', 'traceback'])
 
+
 class DateSerializer(Serializer):
     """
     Serializer to format datetimes in ISO 8601 but with timezone

--- a/chroma-manager/chroma_core/models/power_control.py
+++ b/chroma-manager/chroma_core/models/power_control.py
@@ -51,6 +51,7 @@ class DeletablePowerControlModel(models.Model):
         except socket.gaierror, e:
             raise ValidationError("Unable to resolve %s: %s" % (address, e))
 
+
 class PowerControlType(DeletablePowerControlModel):
     agent = models.CharField(null = False, blank = False, max_length = 255,
             choices = [(a, a) for a in settings.SUPPORTED_FENCE_AGENTS],

--- a/chroma-manager/requirements.dev
+++ b/chroma-manager/requirements.dev
@@ -18,4 +18,4 @@ pyflakes
 pygraphviz
 sphinx==1.1.3
 werkzeug
-iml-common
+iml-common>=1.1,<1.2

--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -379,7 +379,7 @@ class RealRemoteOperations(RemoteOperations):
                 ping_result2 = Shell.run(['ping', '-c', '1', '-W', '1', address])
                 ping_result2_report = "\n30s later ping: %s" % \
                     print_result(ping_result2)
-                
+
             msg = "Error connecting to %s: %s.\n" \
                   "Please add the following to " \
                   "https://github.com/intel-hpdd/intel-manager-for-lustre/issues/%s\n" \

--- a/chroma-manager/tests/unit/chroma_core/jobs/test_jobs.py
+++ b/chroma-manager/tests/unit/chroma_core/jobs/test_jobs.py
@@ -169,4 +169,3 @@ class InvokeAgentInvoke(object):
         return (self.host_fqdn == other.host_fqdn and
                 self.command == other.command and
                 self.args == other.args)
-


### PR DESCRIPTION
Add check after format to give us confidence that format job has performed task we expected.

Currently for zfs, this just verifies the expected dataset has been created, and that could be improved by verifying that dataset is identified as a valid lustre target.

Initially, adding the PostFormatCheck still a beneficial verification step.