### PR TITLE
vagrant destroy should be called with force within destroy_cluster Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ chroma-dependencies: chroma-agent chroma-manager chroma-diagnostics
 chroma-bundles: chroma-dependencies
 
 destroy_cluster: Vagrantfile
-	vagrant destroy
+	vagrant destroy -f
 	sed -ie '/# VAGRANT START/,/# VAGRANT END/d' ~/.ssh/config
 	sed -ie '/IML Vagrant cluster/d' ~/.ssh/authorized_keys
 	export LIBVIRT_DEFAULT_URI=qemu:///system;                       \


### PR DESCRIPTION
Change _vagrant destroy_ to be called with _force flag_ from within the _destroy_cluster_ base IML Makefile . Otherwise the user has to manually confirm destroying each VM and this is inconvenient in terms of the automation that make can provide.

This is a component of the work described in #201 