### PR TITLE
EPEL check in install seems to be broken

### DIFF
--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -118,7 +118,7 @@ def _check_no_epel():
 
     #  Most often this check will be enough.
     with open(os.devnull, 'wb') as DEVNULL:
-        if (subprocess.call(['yum', 'info', 'epel-release'], stdout=DEVNULL, stderr=DEVNULL) != 0):
+        if (subprocess.call(['yum', 'list', 'installed', 'epel-release'], stdout=DEVNULL, stderr=DEVNULL) != 0):
             log.error("Could not find repository: EPEL. Please enable EPEL and then re-run the installer.")
             sys.exit(-1)
 

--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -118,6 +118,8 @@ def _check_no_epel():
 
     #  Most often this check will be enough.
     with open(os.devnull, 'wb') as DEVNULL:
+        # Debug, this is failing in SSI, verify that it passes when installed
+        subprocess.call(['yum', 'install', '-y', 'epel-release'], stdout=DEVNULL, stderr=DEVNULL)
         if (subprocess.call(['yum', 'list', 'installed', 'epel-release'], stdout=DEVNULL, stderr=DEVNULL) != 0):
             log.error("Could not find repository: EPEL. Please enable EPEL and then re-run the installer.")
             sys.exit(-1)


### PR DESCRIPTION
"_check_no_epel()" routine within the install script seems to be broken

The routine tests the output of _yum info epel-release_ and if this returns zero return code, EPEL is assumed to have been installed.

The info command will return with return code zero even if the package is not installed, therefore this is an inappropriate test.

Suggest verifying the package is installed using _yum list installed epel-release_