### PR TITLE
mount.lustre failed: Cannot send after transport endpoint shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,8 @@ install_production: reset_cluster
 # To run a specific test:
 # make TESTS=tests/integration/shared_storage_configuration/test_example_api_client.py:TestExampleApiClient.test_login ssi_tests
 # set NOSE_ARGS="-x" to stop on the first failure
-ssi_tests: reset_cluster
+# ssi_tests: reset_cluster
+ssi_tests:
 	chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main $@
 
 efs_tests: reset_cluster

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
@@ -43,11 +43,24 @@ set -ex
 # 'duck-like' replacement for fence -agents since cman depends on
 # fence-agents
 yum -y install expect cman
+
+# DEBUG: cleanup
+yum -y remove epel-release chroma-manager* || true
+pid=$(pgrep -o -x nginx)
+echo $pid
+echo $pid
+kill $pid || true
+yum clean all
+yum clean --enablerepo=base metadata
+yum -y install epel-release
+rm -f /var/log/chroma/install.log
+
 # Install from the installation package
 cd /tmp
 rm -rf ${ARCHIVE_NAME%.tar.gz}
 tar xzvf $ARCHIVE_NAME
 cd ${ARCHIVE_NAME%.tar.gz}
+echo 'Installing Manager'
 if ! expect ../install.exp $CHROMA_USER $CHROMA_EMAIL $CHROMA_PASS ${CHROMA_NTP_SERVER:-localhost}; then
     rc=\${PIPESTATUS[0]}
     cat /var/log/chroma/install.log
@@ -123,7 +136,16 @@ source $CHROMA_DIR/chroma-manager/tests/framework/integration/utils/install_clie
 
 # Install and setup integration tests on integration test runner
 if ! $JENKINS; then
+<<<<<<< Updated upstream
     CMIT=$(ls chroma-manager/dist/chroma-manager-integration-tests-*.x86_64.rpm)
+=======
+    package_name="chroma-manager-integration-tests-*.x86_64.rpm"
+    locations="chroma-manager/dist\nchroma-manager/"
+    for location in $locations; do
+        [[ -z "$CMIT" ]] && CMIT=$(ls $location/$package_name) || true
+    done
+    [[ -z "$CMIT" ]] && echo "Could not find $package_name in locations: $locations"
+>>>>>>> Stashed changes
 fi
 scp $CMIT $CLUSTER_CONFIG root@$TEST_RUNNER:/root/
 ssh root@$TEST_RUNNER <<EOF

--- a/chroma-manager/tests/integration/core/chroma_integration_testcase.py
+++ b/chroma-manager/tests/integration/core/chroma_integration_testcase.py
@@ -425,12 +425,26 @@ class ChromaIntegrationTestCase(ApiTestCaseWithTestReset):
         filesystem_id = response.json['filesystem']['id']
         command_id = response.json['command']['id']
 
-        self.wait_for_command(
-            self.chroma_manager,
-            command_id,
-            verify_successful=verify_successful,
-            timeout = LONG_TEST_TIMEOUT
-        )
+        def check_for_issue_107():
+            command = self.get_json_by_uri('/api/command/%s/' % command_id)
+            for job_uri in command['jobs']:
+                job = self.get_json_by_uri(job_uri)
+                job_steps = [self.get_json_by_uri(s) for s in job['steps']]
+                if job['errored']:
+                    for step in job_steps:
+                        if step['class_name'] == 'MountOrImportStep' and step['state'] == 'failed':
+                            return True
+
+            return False
+
+        self._fetch_help(lambda: self.wait_for_command(self.chroma_manager,
+                                                       command_id,
+                                                       verify_successful=verify_successful,
+                                                       timeout=LONG_TEST_TIMEOUT),
+                         ['tom.nabarro@intel.com'],
+                         'Investigation of issue #107, starting filesystem/start target/MountOrImportStep',
+                         lambda: check_for_issue_107(),
+                         99999)
 
         # Verify mgs and fs targets in pacemaker config for hosts
         self.remote_operations.check_ha_config(hosts, filesystem['name'])


### PR DESCRIPTION
## This is being tracked in: https://jira.hpdd.intel.com/browse/LU-9838

The pertinent failure string seems to be 
*mount.lustre: mount /dev/sdb at /mnt/testfs-OST0001 failed: Cannot send after transport endpoint shutdown*

Failure is repeatable and can be seen on SSI runs 501, 502, 504

The lustre package versions are as follows:
*lustre-client-2.9.59_35_gc1d70a4*
*lustre-2.9.59_35_gc1d70a4*

http://jenkins.lotus.hpdd.lab.intel.com/job/integration-tests-shared-storage-configuration/arch=x86_64,distro=el7/501//consoleFull

```test_copytool_remove (tests.integration.shared_storage_configuration.test_hsm.TestHsmCopytoolManagement) ... ERROR
ERROR
Traceback (most recent call last):
  File "/usr/share/chroma-manager/tests/integration/shared_storage_configuration/test_hsm.py", line 84, in setUp
    filesystem_id = self.create_filesystem_standard(self.TEST_SERVERS, hsm = True)
  File "/usr/share/chroma-manager/tests/integration/core/chroma_integration_testcase.py", line 368, in create_filesystem_standard
    'conf_params': {}})
  File "/usr/share/chroma-manager/tests/integration/core/chroma_integration_testcase.py", line 432, in create_filesystem
    timeout = LONG_TEST_TIMEOUT
  File "/usr/share/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py", line 336, in wait_for_command
    self.assertFalse(command['errored'] or command['cancelled'], command)
AssertionError: {u'jobs': [u'/api/job/57/', u'/api/job/58/', u'/api/job/59/', u'/api/job/60/', u'/api/job/61/', u'/api/job/62/', u'/api/job/63/', u'/api/job/64/', u'/api/job/65/', u'/api/job/66/', u'/api/job/67/', u'/api/job/68/', u'/api/job/69/', u'/api/job/70/', u'/api/job/71/', u'/api/job/72/', u'/api/job/73/', u'/api/job/74/'], u'complete': True, u'created_at': u'2017-06-27T22:59:07.145542+00:00', u'message': u'Creating filesystem testfs', u'cancelled': True, u'errored': True, u'resource_uri': u'/api/command/17/', u'id': u'17', u'logs': 
```

```Step 118 failed:
step_count: 2
console: modprobe osd_ldiskfs: 0
mount -t lustre /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14 /mnt/testfs-OST0001: 108
mount.lustre: increased /sys/block/sdb/queue/max_sectors_kb from 512 to 16384
mount.lustre: mount /dev/sdb at /mnt/testfs-OST0001 failed: Cannot send after transport endpoint shutdown
description: RegisterTargetStep: {'device_path': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14', 'primary_host': <ManagedHost: lotus-55vm18.lotus.hpdd.lab.intel.com>, 'mount_point': u'/mnt/testfs-OST0001', 'backfstype': 'ldiskfs', 'target': <ManagedTarget: testfs-OST0001>}
class_name: RegisterTargetStep
backtrace: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/chroma_agent/device_plugins/action_runner.py", line 164, in run
  File "/usr/lib/python2.7/site-packages/chroma_agent/plugin_manager.py", line 305, in run
  File "/usr/lib/python2.7/site-packages/chroma_agent/action_plugins/manage_targets.py", line 282, in register_target
  File "/usr/lib/python2.7/site-packages/chroma_agent/chroma_common/filesystems/filesystem_ldiskfs.py", line 61, in mount
RuntimeError: Error (108) mounting '/mnt/testfs-OST0001': '' 'mount.lustre: increased /sys/block/sdb/queue/max_sectors_kb from 512 to 16384
mount.lustre: mount /dev/sdb at /mnt/testfs-OST0001 failed: Cannot send after transport endpoint shutdown
created_at: 2017-06-27T22:59:52.549857+00:00
args: {u'device_path': u'/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_disk14', u'primary_host': u'lotus-55vm18.lotus.hpdd.lab.intel.com', u'mount_point': u'/mnt/testfs-OST0001', u'backfstype': u'ldiskfs', u'target': u'testfs-OST0001'}
modified_at: 2017-06-27T22:59:54.742321+00:00
step_index: 0
state: failed
result: 
resource_uri: /api/step/118/
id: 118
log: 
```