### PR TITLE
Remote commands should not expect input

### DIFF
--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -412,6 +412,18 @@ class RealRemoteOperations(RemoteOperations):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
+        # the set -e just sets up a fail-safe execution environment where
+        # any shell commands in command that fail and are not error checked
+        # cause the shell to fail, alerting the caller that one of their
+        # commands failed unexpectedly
+        command = "set -e; %s" % command
+
+        # exec 0<&- being prefixed to the shell command string below closes
+        # the shell's stdin as we don't expect any uses of remote_command()
+        # to read from stdin
+        if not buffer:
+            command = "exec 0<&-; %s" % command
+
         args = {'username': 'root'}
         # If given an ssh_config file, require that it defines
         # a private key and username for accessing this host

--- a/chroma-manager/tests/integration/core/utility_testcase.py
+++ b/chroma-manager/tests/integration/core/utility_testcase.py
@@ -106,7 +106,14 @@ class UtilityTestCase(TestCase):
         transport.set_keepalive(20)
         channel = transport.open_session()
         channel.settimeout(timeout)
-        channel.exec_command(command)
+        # exec 0<&- being prefixed to the shell command string below closes
+        # the shell's stdin as we don't expect any uses of remote_command()
+        # to read from stdin
+        # the set -e just sets up a fail-safe execution environment where
+        # any shell commands in command that fail and are not error checked
+        # cause the shell to fail, alerting the caller that one of their
+        # commands failed unexpectedly
+        channel.exec_command("exec 0<&-; set -e; %s" % command)
         exit_status = channel.recv_exit_status()
         stdout = channel.makefile('rb').read()
         stderr = channel.makefile_stderr('rb').read()

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -179,7 +179,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         for server in config['lustre_servers']:
             self.remote_command(
                 server['address'],
-                'partprobe; sync; sync'
+                'partprobe || true; sync; sync'
             )
 
         self._save_modified_config()


### PR DESCRIPTION
Fixes #232

If we execute a remote command that expects input it will block
forever waiting for that input.

Make sure that remote commands don't wait for input by closing
stdin.  This will have the effect that any command reading stdin
(of which there shouldn't be any) get an EBADF which should fail
the command obviously enough that the developer can see why it
was looking for input and rectify that.

This of course does not apply when to _ssh_address() when it has
buffer set, so be conditional on that.

 - update _ssh_address() and remote_command() to prefix command
   with "exec 0<&-" to close that shell's stdin, effectively
   causing any command that wants input to get a EBADF
   - only if buffer == None for _ssh_address()
   - experimentation yields that closing stdin can only be
     done in the remote shell and not by the caller/paramiko
     most likely because the ssh protocol doesn't even support
     starting a remote shell with it's stdin closed
 - we also want to "set -e" in the remote shell so that any
   command that does read from stdin and gets an EBADF and
   exits with a failure causes the whole remote shell to exit
   with a failure
   - additionally "set -e" is just a good shell programming
     practice in general and should always be enabled as it
     highlights and traps commands that are not checking their
     exit status and properly fails out the shell when one of
     it's commands fails
     - if a command is expected and allowed to fail, it should
       be explicitly allowed that with something like "|| true"
     - just because it's sh programming should not mean that
       error checking is optional
 - partprobe can fail because of:
    WARNING: the kernel failed to re-read the partition table on /dev/vda (Device or resource busy).  As a result, it may not reflect all of your changes until after reboot.
   - make an allowance for it

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>