### PR TITLE
chroma-diagnostics shell commands should be time bounded

### DIFF
--- a/chroma-diagnostics/chroma-diagnostics.spec
+++ b/chroma-diagnostics/chroma-diagnostics.spec
@@ -15,6 +15,7 @@ Prefix: %{_prefix}
 BuildArch: noarch
 Vendor: Intel(R) Corporation
 Requires: python-argparse
+Requires: python-subprocess32
 Requires: xz-lzma-compat
 
 %description

--- a/chroma-diagnostics/chroma_diagnostics/cli.py
+++ b/chroma-diagnostics/chroma_diagnostics/cli.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 import socket
 import logging
-import subprocess
+import subprocess32 as subprocess
 from datetime import datetime, timedelta
 import time
 import argparse
@@ -42,15 +42,15 @@ logrotate_logs = {
                   ]}
 
 
-def run_command(cmd, out, err):
+def run_command(cmd, out, err, timeout=300):
 
     try:
-        p = subprocess.Popen(cmd, stdout = out, stderr = err)
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
     except OSError:
         #  The cmd in this case could not run, skipping
         return None
     else:
-        p.wait()
+        p.wait(timeout=timeout)
         try:
             out.flush()
         except AttributeError:
@@ -64,8 +64,8 @@ def run_command(cmd, out, err):
         return p
 
 
-def run_command_output_piped(cmd):
-    return run_command(cmd, subprocess.PIPE, subprocess.PIPE)
+def run_command_output_piped(cmd, timeout=300):
+    return run_command(cmd, subprocess.PIPE, subprocess.PIPE, timeout)
 
 
 def save_command_output(fn, cmd, output_directory):

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
@@ -79,12 +79,10 @@ class TestFilesystemSameNameHYD832(ChromaIntegrationTestCase):
         # Filter out the paths by removing anything with a leading /.
         datasets = [dataset for dataset in datasets if dataset.startswith('/') is False]
 
-        self.remote_operations.stop_agents(s['address'] for s in self.TEST_SERVERS[:4])
         self.cleanup_zfs_pools(self.TEST_SERVERS[:4],
                                self.CZP_REMOVEDATASETS | self.CZP_EXPORTPOOLS,
                                datasets,
                                True)
-        self.remote_operations.start_agents(s['address'] for s in self.TEST_SERVERS[:4])
 
         # Our other FS should be untouched
         self.assertEqual(len(self.chroma_manager.get("/api/filesystem/").json['objects']), 1)


### PR DESCRIPTION
Fixes #237

chroma-diagnostics runs a lot of shell commands to gather it's data.

These commands should be time bounded to prevent them from blocking chroma-diagnostics forever in the case where a userspace command hangs indefinitely because there has been a kernel panic of some kind.