### PR TITLE
Prevent testing with ZFS

### DIFF
--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json
@@ -120,14 +120,14 @@
     ],
     "lustre_devices": [
         {"path_index": 0,
-            "backend_filesystem": "zfs"},
+            "backend_filesystem": "linux"},
         {"path_index": 1,
             "backend_filesystem": "linux"},
         {"path_index": 2,
-            "backend_filesystem": "zfs"},
+            "backend_filesystem": "linux"},
         {"path_index": 3,
             "backend_filesystem": "linux"},
         {"path_index": 4,
-            "backend_filesystem": "zfs"}
+            "backend_filesystem": "linux"}
     ]
 }

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
@@ -79,12 +79,10 @@ class TestFilesystemSameNameHYD832(ChromaIntegrationTestCase):
         # Filter out the paths by removing anything with a leading /.
         datasets = [dataset for dataset in datasets if dataset.startswith('/') is False]
 
-        self.remote_operations.stop_agents(s['address'] for s in self.TEST_SERVERS[:4])
         self.cleanup_zfs_pools(self.TEST_SERVERS[:4],
                                self.CZP_REMOVEDATASETS | self.CZP_EXPORTPOOLS,
                                datasets,
                                True)
-        self.remote_operations.start_agents(s['address'] for s in self.TEST_SERVERS[:4])
 
         # Our other FS should be untouched
         self.assertEqual(len(self.chroma_manager.get("/api/filesystem/").json['objects']), 1)


### PR DESCRIPTION
Due to a number of current issues with ZFS in IML, stop testing
with it, at least until those issues can be worked out.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>