### PR TITLE
Rename "linux" to "ldiskfs"

### DIFF
--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/existing_filesystem_configuration_cluster_cfg.json
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/existing_filesystem_configuration_cluster_cfg.json
@@ -124,14 +124,14 @@
     },
     "lustre_devices": [
         {"path_index": 0,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 1,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 2,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 3,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 4,
-            "backend_filesystem": "linux"}
+            "backend_filesystem": "ldiskfs"}
     ]
 }

--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main
@@ -58,7 +58,7 @@ for dne in true false; do
             export TEST_SPECIFIC_CLUSTER_CONFIG=$PWD/existing_filesystem_configuration_cluster_cfg_${device_type}_HA_is_${test_ha}_dne_is_${dne}.json
 
             sed -e "s/\(\"device_type\": *\)\"linux\"/\1\"${device_type}\"/g" $CLUSTER_CONFIG > $TEST_SPECIFIC_CLUSTER_CONFIG
-            sed -i -e "s/\(\"backend_filesystem\": *\)\"linux\"/\1\"${device_type}\"/g" $TEST_SPECIFIC_CLUSTER_CONFIG
+            sed -i -e "s/\(\"backend_filesystem\": *\)\"ldiskfs\"/\1\"${device_type}\"/g" $TEST_SPECIFIC_CLUSTER_CONFIG
             sed -i -e "s/\(\"test_ha\"\: *\)true/\1${test_ha}/g" $TEST_SPECIFIC_CLUSTER_CONFIG
 
             # One Kind entry is defined as "kind": "OSTorMDT" set it to be an OST for !dne or an MDT for dne

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json
@@ -120,14 +120,14 @@
     ],
     "lustre_devices": [
         {"path_index": 0,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 1,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 2,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 3,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 4,
-            "backend_filesystem": "linux"}
+            "backend_filesystem": "ldiskfs"}
     ]
 }

--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -876,7 +876,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
 
     @classmethod
     def linux_devices_exist(cls):
-        return any(lustre_device['backend_filesystem'] == 'linux' for lustre_device in config['lustre_devices'])
+        return any(lustre_device['backend_filesystem'] == 'ldiskfs' for lustre_device in config['lustre_devices'])
 
     @classmethod
     def zfs_devices_exist(cls):
@@ -1006,7 +1006,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         # Erase all volumes if the config does not indicate that there is already
         # a pre-existing file system (in the case of the monitoring only tests).
         for lustre_device in config['lustre_devices']:
-            if lustre_device['backend_filesystem'] == 'linux':
+            if lustre_device['backend_filesystem'] == 'ldiskfs':
                 linux_device = TestBlockDevice('linux', first_test_server['device_paths'][lustre_device['path_index']])
 
                 self.execute_simultaneous_commands(linux_device.destroy_commands,

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_targets.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_targets.py
@@ -74,7 +74,7 @@ class TestReformatTarget(ChromaIntegrationTestCase):
         """
         # Pick one victim volume ahead of running tests
         device_index = next(device['path_index'] for device in config['lustre_devices'] if
-                            device['backend_filesystem'] == 'linux')
+                            device['backend_filesystem'] == 'ldiskfs')
         host_config = config['lustre_servers'][0]
         device_path = host_config['device_paths'][device_index]
 

--- a/chroma-manager/tests/simulator.json
+++ b/chroma-manager/tests/simulator.json
@@ -186,14 +186,14 @@
     ],
         "lustre_devices": [
         {"path_index": 0,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 1,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 2,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 3,
-            "backend_filesystem": "linux"},
+            "backend_filesystem": "ldiskfs"},
         {"path_index": 4,
-            "backend_filesystem": "linux"}
+            "backend_filesystem": "ldiskfs"}
     ]
 }


### PR DESCRIPTION
_linux_ is the name of an O/S kernel.  _ldiskfs_ is the name of a filesystem type.  _ldiskfs_ is analogous to _zfs_.  _linux_ is not. 

Replace the use of _linux_ where _ldiskfs_ is really what is intended.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>