### PR TITLE
Add extra argument to mock

### DIFF
--- a/chroma-agent/tests/device_plugins/test_action_runner.py
+++ b/chroma-agent/tests/device_plugins/test_action_runner.py
@@ -79,7 +79,7 @@ class ActionTestCase(unittest.TestCase):
         self.mock_send_message_call_count += 1
         self.mock_send_message_lock.release()
 
-    def mock_run(self, args, logger, result_store, timeout):
+    def mock_run(self, args, logger, result_store, timeout, shell=False):
         return self.MOCK_SUBPROCESSES[tuple(args)]()
 
     def setUp(self):


### PR DESCRIPTION
It looks like we need to add an extra
argument to mock_run to get our
unit tests passing again.

Signed-off-by: Joe Grund <joe.grund@intel.com>