### PR TITLE
Allow the user to override repo locations

### DIFF
--- a/chroma-bundles/Makefile
+++ b/chroma-bundles/Makefile
@@ -28,7 +28,7 @@ package: subdirs $(PROFILES) lesskey.out create_installer
 		--show-transformed-names \
 		-C ../ \
 		--exclude README-INTERNAL \
-	    -czvf $(SHORT_ARCHIVE_NAME)-$(ARCHIVE_VERSION).tar.gz $(WORKDIR)/create_installer $(WORKDIR)/install $(WORKDIR)/lesskey.out $(foreach profile,$(PROFILES),$(WORKDIR)/$(profile)) $(foreach subdir,$(SUBDIRS),$(WORKDIR)/$(shell echo $(subdir)/*.tar.gz))
+	    -czvf $(SHORT_ARCHIVE_NAME)-$(ARCHIVE_VERSION).tar.gz $(WORKDIR)/chroma_support.repo $(WORKDIR)/create_installer $(WORKDIR)/install $(WORKDIR)/lesskey.out $(foreach profile,$(PROFILES),$(WORKDIR)/$(profile)) $(foreach subdir,$(SUBDIRS),$(WORKDIR)/$(shell echo $(subdir)/*.tar.gz))
 
 lesskey.out: lesskey.in
 	lesskey -o $@ $<

--- a/chroma-bundles/chroma_support.repo
+++ b/chroma-bundles/chroma_support.repo
@@ -1,0 +1,27 @@
+[managerforlustre-manager-for-lustre]
+name=Copr repo for manager-for-lustre owned by managerforlustre
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+
+[extras]
+name=CentOS-7 - Extras
+#baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras&infra=$infra
+enabled=1
+gpgcheck=1
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
+
+[epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7

--- a/chroma-bundles/include/find_deps.py
+++ b/chroma-bundles/include/find_deps.py
@@ -91,6 +91,7 @@ class YumDepFinder(object):
                repo.id != "extras" and repo.id != "extras-centos7.3-x86_64" and \
                repo.id != "addon-epel7-x86_64" and repo.id != "epel" and \
                repo.id != "ngompa-dnf-el7" and \
+               repo.id != "managerforlustre-manager-for-lustre" and \
                repo.id != "copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre_epel-7-x86_64_":
                 repo.disable()
 

--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -324,38 +324,19 @@ def _old_bundles():
         bundles[bundle_name] = meta
 
     return bundles
-
+    
 def _create_support_repos():
 
-    with open("/etc/yum.repos.d/chroma_support.repo", "w+") as repo:
-        repo.write("""[managerforlustre-manager-for-lustre]
-name=Copr repo for manager-for-lustre owned by managerforlustre
-baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-
-[extras]
-name=CentOS-7 - Extras
-#baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras&infra=$infra
-enabled=1
-gpgcheck=1
-gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
-
-[epel]
-name=Extra Packages for Enterprise Linux 7 - $basearch
-#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-failovermethod=priority
-enabled=1
-gpgcheck=1
-#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
-""")
+    repodir = "/etc/yum.repos.d"
+    repofile = "chroma_support.repo"
+    target_path = os.path.join(repodir, repofile)
+    if not os.path.exists(target_path):
+        try:
+            shutil.copy(repofile, repodir)
+        except:
+            log.debug("Failed to create %s." % target_path)
+            log.info("Failed to create %s." % target_path)
+            sys.exit(-1)
 
 def _create_manager_repo():
     manager_repo_dir = tempfile.mkdtemp()
@@ -633,7 +614,7 @@ def _check_repos():
                      'You may also see this message if Red Hat Satellite repos are enabled.\n'
                      'To skip this check, please rerun with the --no-repo-check flag.')
             log.info("URLs that failed: %s" % ' '.join(urls))
-            sys.exit(1)
+            sys.exit(-11)
 
 
 def main():

--- a/chroma-manager/MANIFEST.in
+++ b/chroma-manager/MANIFEST.in
@@ -14,6 +14,7 @@ include tests/sample_data/*
 include tests/integration/run_tests
 include tests/integration/*/*.json
 include tests/integration/core/clear_ha_el?.sh
+include storage_server.repo
 graft ui-modules/node_modules
 graft licenses
 graft polymorphic

--- a/chroma-manager/Makefile
+++ b/chroma-manager/Makefile
@@ -178,6 +178,7 @@ tarball: version ui-modules
 	# workaround setuptools
 	touch .chroma-manager.py
 	touch .production_supervisord.conf
+	touch .storage_server.repo
 	if ! python setup.py sdist > sdist.out; then       \
 	    echo "python setup.py sdist failed.  stdout:"; \
 	    cat sdist.out;                                 \

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -159,6 +159,7 @@ echo -e "/^DEBUG =/s/= .*$/= False/\nwq" | ed settings.py 2>/dev/null
 %{__python} setup.py -q build
 # workaround setuptools inanity for top-level datafiles
 cp -a chroma-manager.py build/lib
+cp -a storage_server.repo build/lib
 cp -a production_supervisord.conf build/lib
 cp -a chroma-manager.conf.template build/lib
 cp -a mime.types build/lib
@@ -341,6 +342,7 @@ fi
 %{manager_root}/chroma_help/*
 %{manager_root}/chroma_core/fixtures/*
 %{manager_root}/polymorphic/COPYING
+%config(noreplace) %{manager_root}/storage_server.repo
 # Stuff below goes into the -cli/-lib packages
 %exclude %{manager_root}/chroma_cli
 %exclude %{python_sitelib}/*.egg-info/

--- a/chroma-manager/chroma_agent_comms/views.py
+++ b/chroma-manager/chroma_agent_comms/views.py
@@ -361,56 +361,8 @@ def setup(request, key):
         return token_error
 
     # the minimum repos needed on a storage server now
-    repos = """[ngompa-dnf-el7]
-name=Copr repo for dnf-el7 owned by ngompa
-baseurl=https://copr-be.cloud.fedoraproject.org/results/ngompa/dnf-el7/epel-7-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/ngompa/dnf-el7/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
+    repos = open("/usr/share/chroma-manager/storage_server.repo").read()
 
-[lustre]
-name=Lustre Server
-baseurl=https://build.whamcloud.com/lustre-b2_10_last_successful_server/
-enabled=1
-gpgcheck=0
-
-[lustre-client]
-name=Lustre Client
-baseurl=https://build.whamcloud.com/lustre-b2_10_last_successful_client/
-enabled=1
-gpgcheck=0
-
-[e2fsprogs]
-name=Lustre e2fsprogs
-baseurl=https://downloads.hpdd.intel.com/public/e2fsprogs/latest/el7/
-enabled=1
-gpgcheck=0
-
-[managerforlustre-manager-for-lustre]
-name=Copr repo for manager-for-lustre owned by managerforlustre
-baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-
-[epel]
-name=Extra Packages for Enterprise Linux 7 - $basearch
-#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-failovermethod=priority
-enabled=1
-gpgcheck=1
-#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-gpgkey=https://muug.ca/mirror/fedora-epel/RPM-GPG-KEY-EPEL-7
-
-"""
     repo_names = token.profile.bundles.values_list('bundle_name', flat=True)
     for bundle in Bundle.objects.all():
         if bundle.bundle_name != "external":

--- a/chroma-manager/setup.py
+++ b/chroma-manager/setup.py
@@ -28,7 +28,9 @@ setup(
     # file creation/cleanup in the Makefile) to deal with the fact
     # that setuptools wants to strip the first character off the filename.
     package_data = {
-        '': [".chroma-manager.py", ".production_supervisord.conf", ".chroma-manager.conf.template", ".mime.types"],
+        '': [".chroma-manager.py", ".production_supervisord.conf",
+             ".storage_server.repo",
+             ".chroma-manager.conf.template", ".mime.types"],
         'chroma_core': ["fixtures/default_power_types.json"],
         'polymorphic': ["COPYING"],
         'tests': ["integration/run_tests",

--- a/chroma-manager/storage_server.repo
+++ b/chroma-manager/storage_server.repo
@@ -1,0 +1,48 @@
+[ngompa-dnf-el7]
+name=Copr repo for dnf-el7 owned by ngompa
+baseurl=https://copr-be.cloud.fedoraproject.org/results/ngompa/dnf-el7/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/ngompa/dnf-el7/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+
+[lustre]
+name=Lustre Server
+baseurl=https://build.whamcloud.com/lustre-b2_10_last_successful_server/
+enabled=1
+gpgcheck=0
+
+[lustre-client]
+name=Lustre Client
+baseurl=https://build.whamcloud.com/lustre-b2_10_last_successful_client/
+enabled=1
+gpgcheck=0
+
+[e2fsprogs]
+name=Lustre e2fsprogs
+baseurl=https://downloads.hpdd.intel.com/public/e2fsprogs/latest/el7/
+enabled=1
+gpgcheck=0
+
+[managerforlustre-manager-for-lustre]
+name=Copr repo for manager-for-lustre owned by managerforlustre
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+
+[epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgkey=https://muug.ca/mirror/fedora-epel/RPM-GPG-KEY-EPEL-7

--- a/cluster-sim/Makefile
+++ b/cluster-sim/Makefile
@@ -4,7 +4,7 @@ include ../include/Makefile.version
 ifeq ($(DISTRO_TAG), el6)
 	FENCE_AGENTS_URL    := http://vault.centos.org/6.4/os/x86_64/Packages/fence-agents-3.1.5-25.el6.x86_64.rpm
 else ifeq ($(DISTRO_TAG), el7)
-	FENCE_AGENTS_URL    := http://mirror.centos.org/centos-7/7/os/x86_64/Packages/fence-agents-{common,apc}-4.0.11-47.el7.x86_64.rpm
+	FENCE_AGENTS_URL    := http://mirror.centos.org/centos-7/7/os/x86_64/Packages/fence-agents-{common,apc}-4.0.11-66.el7.x86_64.rpm
 else
 	$(error "Unknown major distro version $(DISTRO_TAG)")
 endif


### PR DESCRIPTION
This is done by first setting repo locations in chroma_support.repo
in the installation directory.  This file will NOT override an
existing /etc/yum.repos.d/chroma_support.repo file however.

Then once the manager is installed, storage server repo overrides
can be made to /usr/share/chroma-manager/storage_server.repo.  This
file is marked as a configuration file in the RPM so upgrades won't
override changes to this file.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/277)
<!-- Reviewable:end -->
