### PR TITLE
Pin repos to b2.10.1

### DIFF
--- a/chroma-manager/storage_server.repo
+++ b/chroma-manager/storage_server.repo
@@ -11,13 +11,13 @@ enabled_metadata=1
 
 [lustre]
 name=Lustre Server
-baseurl=https://build.whamcloud.com/lustre-b2_10_last_successful_server/
+baseurl=https://build.hpdd.intel.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
 enabled=1
 gpgcheck=0
 
 [lustre-client]
 name=Lustre Client
-baseurl=https://build.whamcloud.com/lustre-b2_10_last_successful_client/
+baseurl=https://build.hpdd.intel.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
 enabled=1
 gpgcheck=0
 

--- a/chroma-manager/storage_server.repo
+++ b/chroma-manager/storage_server.repo
@@ -11,13 +11,13 @@ enabled_metadata=1
 
 [lustre]
 name=Lustre Server
-baseurl=https://build.hpdd.intel.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
+baseurl=https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
 enabled=1
 gpgcheck=0
 
 [lustre-client]
 name=Lustre Client
-baseurl=https://build.hpdd.intel.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
+baseurl=https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
 enabled=1
 gpgcheck=0
 

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -109,11 +109,11 @@ set_defaults() {
         export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
-        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type"
+        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
         export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_x86_64_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_x86_64_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
     fi
 } # end of set_defaults()

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -109,8 +109,8 @@ set_defaults() {
         export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
-        export LUSTRE_SERVER_URL="https://build.hpdd.intel.com/lustre-b2_10_last_successful_server/"
-        export LUSTRE_CLIENT_URL="https://build.hpdd.intel.com/lustre-b2_10_last_successful_client/"
+        export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/lastSuccessful/archive/artifacts/"
+        export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/lastSuccessful/archive/artifacts/"
         # these should be determined from the above
         export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-b2_10_last_successful_server_.repo"
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-b2_10_last_successful_client_.repo"

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -102,17 +102,17 @@ set_defaults() {
     # if you use this, don't forget to update chroma-manager/chroma_agent_comms/views.py
     #LUSTRE_REVIEW_BUILD="12345"
     if [ -n "$LUSTRE_REVIEW_BUILD" ]; then
-        BASE_URL="https://build.whamcloud.com/lustre-reviews/configurations/axis-arch/\\\$basearch/axis-build_type"
+        BASE_URL="https://build.hpdd.intel.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
         export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/builds/$LUSTRE_REVIEW_BUILD/archive/artifacts/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/builds/$LUSTRE_REVIEW_BUILD/archive/artifacts/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
-        export LUSTRE_SERVER_URL="https://build.whamcloud.com/lustre-b2_10_last_successful_server/"
-        export LUSTRE_CLIENT_URL="https://build.whamcloud.com/lustre-b2_10_last_successful_client/"
+        export LUSTRE_SERVER_URL="https://build.hpdd.intel.com/lustre-b2_10_last_successful_server/"
+        export LUSTRE_CLIENT_URL="https://build.hpdd.intel.com/lustre-b2_10_last_successful_client/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-b2_10_last_successful_server_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-b2_10_last_successful_client_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-b2_10_last_successful_server_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-b2_10_last_successful_client_.repo"
     fi
 } # end of set_defaults()

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -102,17 +102,18 @@ set_defaults() {
     # if you use this, don't forget to update chroma-manager/chroma_agent_comms/views.py
     #LUSTRE_REVIEW_BUILD="12345"
     if [ -n "$LUSTRE_REVIEW_BUILD" ]; then
-        BASE_URL="https://build.hpdd.intel.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
+        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-reviews/configurations/axis-arch/\\\$basearch/axis-build_type"
         export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/builds/$LUSTRE_REVIEW_BUILD/archive/artifacts/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/builds/$LUSTRE_REVIEW_BUILD/archive/artifacts/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
+        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
         export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/lastSuccessful/archive/artifacts/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/lastSuccessful/archive/artifacts/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-b2_10_last_successful_server_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.hpdd.intel.com_lustre-b2_10_last_successful_client_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-b2_10_last_successful_server_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-b2_10_last_successful_client_.repo"
     fi
 } # end of set_defaults()

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -109,11 +109,11 @@ set_defaults() {
         export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
-        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
+        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type"
         export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_x86_64_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_x86_64_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
     fi
 } # end of set_defaults()

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -110,10 +110,10 @@ set_defaults() {
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
         BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
-        export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/lastSuccessful/archive/artifacts/"
-        export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/lastSuccessful/archive/artifacts/"
+        export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
+        export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-b2_10_last_successful_server_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-b2_10_last_successful_client_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
     fi
 } # end of set_defaults()


### PR DESCRIPTION
Now that we are nearing RC, and b2.10.1 is in RC1, we should pin IML against the b2.10.1RC.

This will ensure we are testing the code planned to be shipped, and are not having shifting updates of Lustre.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/286)
<!-- Reviewable:end -->
