### PR TITLE
Change exit value from install to -1 from -11

### DIFF
--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -614,7 +614,7 @@ def _check_repos():
                      'You may also see this message if Red Hat Satellite repos are enabled.\n'
                      'To skip this check, please rerun with the --no-repo-check flag.')
             log.info("URLs that failed: %s" % ' '.join(urls))
-            sys.exit(-11)
+            sys.exit(-1)
 
 
 def main():


### PR DESCRIPTION
Clearly an extra '1' digit was inserted.  Remove it.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/300)
<!-- Reviewable:end -->
