### PR TITLE
Integrate device-scanner in IML agent

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -32,6 +32,7 @@ Requires: python2-iml-common1.1
 Requires: systemd-python
 Requires: python-tzlocal
 Requires: python2-toolz
+Requires: iml-device-scanner
 %if 0%{?rhel} > 5
 Requires: util-linux-ng
 %endif

--- a/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
@@ -228,13 +228,8 @@ class BlockDevices(object):
         # matching MM to path back in a list.
 
         def build_paths(x):
-            out = []
-
-            for path in x['paths']:
-                if path.startswith(folder):
-                    out.append((x['major_minor'], path))
-
-            return out
+            return [(x['major_minor'], path) for path in x['paths']
+                    if path.startswith(folder)]
 
         return pipe(self.block_device_nodes.itervalues(),
                     cmapcat(build_paths), dict)

--- a/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
@@ -2,119 +2,207 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-
 import os
-import glob
 import re
 import errno
-import stat
-import time
-
+import socket
+import json
 from chroma_agent.lib.shell import AgentShell
-from chroma_agent.log import console_log, daemon_log
-from chroma_agent import utils
+from toolz.functoolz import pipe
+from toolz.itertoolz import getter
+from toolz.curried import map as cmap, filter as cfilter, mapcat as cmapcat
+
 import chroma_agent.lib.normalize_device_path as ndp
+
 # Python errno doesn't include this code
 errno.NO_MEDIA_ERRNO = 123
 
+DEV_PATH = re.compile('^/dev/[^/]+$')
+DISK_BY_ID_PATH = re.compile('^/dev/disk/by-id/')
+DISK_BY_PATH_PATH = re.compile('^/dev/disk/by-path/')
+MAPPER_PATH = re.compile('^/dev/mapper/')
+
+PRECEDENCE = [
+    MAPPER_PATH, DISK_BY_ID_PATH, DISK_BY_PATH_PATH,
+    re.compile('.+')
+]
+
+
+def get_idx(x):
+    return [index for index, v in enumerate(PRECEDENCE) if v.match(x)][0]
+
+
+def compare(x, y):
+    idx1 = get_idx(x)
+    idx2 = get_idx(y)
+
+    if idx1 == idx2:
+        return 0
+    elif idx1 > idx2:
+        return 1
+
+    return -1
+
+
+def sort_paths(xs):
+    return sorted(xs, cmp=compare)
+
+
+def scanner_cmd(cmd):
+    client = socket.socket(socket.AF_UNIX)
+    client.settimeout(1)
+    client.connect_ex("/var/run/device-scanner.sock")
+    client.sendall(json.dumps({"ACTION": cmd}))
+    client.shutdown(socket.SHUT_WR)
+
+    out = ''
+
+    while True:
+        data = client.recv(1024)
+        size = len(data)
+
+        if size == 0:
+            break
+
+        out += data
+
+    return json.loads(out)
+
+
+def get_default(prop, default_value, x):
+    y = x.get(prop, default_value)
+    return y if y is not None else default_value
+
+
+def get_major_minor(x):
+    return "%s:%s" % (x.get('MAJOR'), x.get('MINOR'))
+
+
+def as_device(x):
+    paths = sort_paths(get_default('PATHS', [], x))
+    path = next(iter(paths), None)
+
+    return {
+        'major_minor': get_major_minor(x),
+        'path': path,
+        'paths': paths,
+        'serial_80': x.get('IML_SCSI_80'),
+        'serial_83': x.get('IML_SCSI_83'),
+        'size': int(get_default('IML_SIZE', 0, x)) * 512,
+        'filesystem_type': x.get('ID_FS_TYPE'),
+        'device_type': x.get('DEVTYPE'),
+        'device_path': x.get('DEVPATH'),
+        'partition_number': x.get('ID_PART_ENTRY_NUMBER'),
+        'is_ro': x.get('IML_IS_RO'),
+        'parent': None
+    }
+
+
+def get_parent_path(p):
+    return os.sep.join(p.split(os.sep)[0:-1])
+
+
+def find_device_by_device_path(p, xs):
+    return next((d for d in xs if d['device_path'] == p), None)
+
+
+def mutate_parent_prop(xs):
+    disks = [x for x in xs if x['device_type'] == 'disk']
+    partitions = [x for x in xs if x['device_type'] == 'partition']
+
+    for x in partitions:
+        parent_path = get_parent_path(x['device_path'])
+        device = find_device_by_device_path(parent_path, disks)
+
+        if device:
+            x['parent'] = device['major_minor']
+
+
+def filter_device(x):
+    # Exclude zero-sized devices
+    if x['size'] == 0 or x['is_ro']:
+        return False
+
+    return True
+
+
+def fetch_device_list():
+    AgentShell.run(["udevadm", "settle"])
+    info = scanner_cmd("info")
+
+    return pipe(info.itervalues(),
+                cmap(as_device), cfilter(filter_device), list)
+
+
+def add_to_ndp(xs, ys):
+    for x in xs:
+        for y in ys:
+            ndp.add_normalized_device(x, y)
+
+
+def build_ndp_from_device(x):
+    paths = x['paths']
+
+    dev_paths = filter(DEV_PATH.match, paths)
+    disk_by_id_paths = filter(DISK_BY_ID_PATH.match, paths)
+    disk_by_path_paths = filter(DISK_BY_PATH_PATH.match, paths)
+    mapper_paths = filter(MAPPER_PATH.match, paths)
+
+    add_to_ndp(dev_paths, disk_by_path_paths)
+    add_to_ndp(dev_paths, disk_by_id_paths)
+    add_to_ndp(disk_by_path_paths, mapper_paths)
+    add_to_ndp(disk_by_id_paths, mapper_paths)
+
 
 class BlockDevices(object):
-    """
-    Reads /sys/block to detect all block devices, resolves SCSI WWIDs where possible, and
-    generates a mapping of major:minor to normalized device node path and vice versa.
-    """
     MAPPERPATH = os.path.join('/dev', 'mapper')
     DISKBYIDPATH = os.path.join('/dev', 'disk', 'by-id')
-    DISKBYPATHPATH = os.path.join('/dev', 'disk', 'by-path')
-    SYSBLOCKPATH = os.path.join('/sys', 'block')
-    MDRAIDPATH = os.path.join('/dev', 'md')
-    DEVPATH = '/dev'
-    MAXRETRIES = 5
-    non_existent_paths = set([])
-    previous_path_status = {}
 
     def __init__(self):
-        self.old_udev = None
-        self._major_minor_to_fstype = {}  # Build this map to retrieve fstype in _device_node
+        (self.block_device_nodes,
+         self.node_block_devices) = self._parse_sys_block()
 
-        for blkid_dev in utils.BlkId().itervalues():
-            major_minor = self._dev_major_minor(blkid_dev['path'])
+    def _parse_sys_block(self):
+        xs = fetch_device_list()
 
-            if major_minor:
-                self._major_minor_to_fstype[major_minor] = blkid_dev['type']
+        mutate_parent_prop(xs)
 
-        self.block_device_nodes, self.node_block_devices = self._parse_sys_block()
+        node_block_devices = reduce(
+            lambda d, x: dict(d, **{x['path']: x['major_minor']}), xs, {})
 
-    def _dev_major_minor(self, path):
-        """ Return a string if 'path' is a block device or link to one, else return None """
+        block_device_nodes = reduce(
+            lambda d, x: dict(d, **{x['major_minor']: x}), xs, {})
 
-        file_status = None
-        retries = self.MAXRETRIES
-        while retries > 0:
-            try:
-                file_status = os.stat(path)
+        map(build_ndp_from_device, xs)
 
-                if path in self.non_existent_paths:
-                    self.non_existent_paths.discard(path)
-                    daemon_log.debug('New device started to respond %s' % path)
-
-                self.previous_path_status[path] = file_status
-                break
-            except OSError as os_error:
-                if os_error.errno not in [errno.ENOENT, errno.ENOTDIR]:
-                    raise
-
-                # An OSError could be raised because a path genuinely doesn't
-                # exist, but it also can be the result of conflicting with
-                # actions that cause devices to disappear momentarily, such as
-                # during a partprobe while it reloads the partition table.
-                # So we retry for a short window to catch those devices that
-                # just disappear momentarily.
-                time.sleep(0.1)
-                retries -= retries if path in self.non_existent_paths else 1
-
-        if file_status is None:
-            if path not in self.non_existent_paths:
-                self.non_existent_paths.add(path)
-                daemon_log.debug('New device failed to respond %s' % path)
-
-            if path not in self.previous_path_status:
-                return None
-
-            file_status = self.previous_path_status.pop(path)
-            daemon_log.debug('Device failed to respond but stored file_status used')
-
-        if stat.S_ISBLK(file_status.st_mode):
-            return "%d:%d" % (os.major(file_status.st_rdev), os.minor(file_status.st_rdev))
-        else:
-            return None
+        return (block_device_nodes, node_block_devices)
 
     def paths_to_major_minors(self, device_paths):
         """
-        Create a list of device major minors for a list of device paths from _path_to_major_minor dict.
+        Create a list of device major minors for a list of
+        device paths from _path_to_major_minor dict.
         If any of the paths come back as None, continue to the next.
 
-        :param device_paths: The list of paths to get the list of major minors for.
-        :return: list of dev_major_minors, or an empty list if any device_path is not found.
+        :param device_paths: The list of paths to get
+            the list of major minors for.
+        :return: list of dev_major_minors, or an empty
+            list if any device_path is not found.
         """
-        device_mms = []
-        for device_path in device_paths:
-            device_mm = self.path_to_major_minor(device_path)
 
-            if device_mm is None:
-                continue
-
-            device_mms.append(device_mm)
-        return device_mms
+        return pipe(device_paths,
+                    cmap(self.path_to_major_minor), cfilter(None), list)
 
     def path_to_major_minor(self, device_path):
         """ Return device major minor for a given device path """
-        return self.node_block_devices.get(ndp.normalized_device_path(device_path))
+        return self.node_block_devices.get(
+            ndp.normalized_device_path(device_path))
 
     def composite_device_list(self, source_devices):
         """
-        This function takes a bunch of devices like MdRaid, EMCPower which are effectively composite devices made up
-        from a collection of other devices and returns that list with the drives and everything nicely assembled.
+        This function takes a bunch of devices like MdRaid, EMCPower
+        which are effectively composite devices made up
+        from a collection of other devices and returns that
+        list with the drives and everything nicely assembled.
         """
         devices = {}
 
@@ -122,9 +210,11 @@ class BlockDevices(object):
             drive_mms = self.paths_to_major_minors(device['device_paths'])
 
             if drive_mms:
-                devices[device['uuid']] = {'path': device["path"],
-                                           'block_device': device['mm'],
-                                           'drives': drive_mms}
+                devices[device['uuid']] = {
+                    'path': device['path'],
+                    'block_device': device['mm'],
+                    'drives': drive_mms
+                }
 
                 # Finally add these devices to the canonical path list.
                 for device_path in device['device_paths']:
@@ -134,149 +224,25 @@ class BlockDevices(object):
 
     def find_block_devs(self, folder):
         # Map of major_minor to path
-        result = {}
-        for path in glob.glob(os.path.join(folder, "*")):
-            mm = self._dev_major_minor(path)
-            if mm:
-                result[mm] = path
+        # Should be able to look at the paths prop for all devs, and put
+        # matching MM to path back in a list.
 
-        return result
+        def build_paths(x):
+            out = []
 
-    def _device_node(self, major_minor, path, size, parent, partition_number):
-        # RHEL6 version of scsi_id is located at a different location to the RHEL7 version
-        # work this out at the start then go with it.
-        scsi_id_cmd = None
+            for path in x['paths']:
+                if path.startswith(folder):
+                    out.append((x['major_minor'], path))
 
-        for scsi_id_command in ["/sbin/scsi_id", "/lib/udev/scsi_id", ""]:
-            if os.path.isfile(scsi_id_command):
-                scsi_id_cmd = scsi_id_command
+            return out
 
-        if scsi_id_cmd == None:
-            raise RuntimeError("Unabled to find scsi_id")
-
-        def scsi_id_command(cmd):
-            rc, out, err = AgentShell.run_old(cmd)
-            if rc:
-                return None
-            else:
-                return out.strip()
-
-        # New scsi_id, always operates directly on a device
-        serial_80 = scsi_id_command([scsi_id_cmd, "-g", "-p", "0x80", path])
-        serial_83 = scsi_id_command([scsi_id_cmd, "-g", "-p", "0x83", path])
-
-        type = self._major_minor_to_fstype.get(major_minor)
-
-        info = {'major_minor': major_minor,
-                'path': path,
-                'serial_80': serial_80,
-                'serial_83': serial_83,
-                'size': size,
-                'filesystem_type': type,
-                'partition_number': partition_number,
-                'parent': parent}
-
-        return info
-
-    def _parse_sys_block(self):
-        mapper_devs = self.find_block_devs(self.MAPPERPATH)
-        by_id_nodes = self.find_block_devs(self.DISKBYIDPATH)
-        by_path_nodes = self.find_block_devs(self.DISKBYPATHPATH)
-        dev_nodes = self.find_block_devs(self.DEVPATH)
-
-        def get_path(major_minor, device_name):
-            # Try to find device nodes for these:
-            fallback_dev_path = os.path.join("/dev/", device_name)
-            # * First look in /dev/mapper
-            if major_minor in mapper_devs:
-                return mapper_devs[major_minor]
-            # * Then try /dev/disk/by-id
-            elif major_minor in by_id_nodes:
-                return by_id_nodes[major_minor]
-            # * Then try /dev/disk/by-path
-            elif major_minor in by_path_nodes:
-                return by_path_nodes[major_minor]
-            # * Then fall back to just /dev
-            elif os.path.exists(fallback_dev_path):
-                return fallback_dev_path
-            else:
-                console_log.warning("Could not find device node for %s (%s)" % (major_minor, fallback_dev_path))
-                return None
-
-        block_device_nodes = {}
-        node_block_devices = {}
-
-        def parse_block_dir(dev_dir, parent = None):
-            """ Parse a dir like /sys/block/sda (must contain 'dev' and 'size') """
-            size = 0
-            device_name = dev_dir.split(os.sep)[-1]
-
-            try:
-                major_minor = open(os.path.join(dev_dir, "dev")).read().strip()
-                size = int(open(os.path.join(dev_dir, "size")).read().strip()) * 512
-            except IOError:
-                pass
-
-            # Exclude zero-sized devices
-            if size == 0:
-                return
-
-            # Exclude ramdisks, floppy drives, obvious cdroms
-            if re.search("^ram\d+$", device_name) or\
-               re.search("^fd\d+$", device_name) or\
-               re.search("^sr\d+$", device_name):
-                return
-
-            # Exclude read-only devices and removed media or devices
-            try:
-                # Never use 'w' in the built-in open() or it'll create a 0 length file where a
-                # device was removed!
-                fd = os.open("/dev/%s" % device_name, os.O_WRONLY)
-            except OSError, e:
-                # EROFS: Device is read-only
-                # ENOENT: No such file or directory
-                # NO_MEDIA_ERRNO: No medium found
-                if e.errno in [errno.EROFS, errno.ENOENT, errno.NO_MEDIA_ERRNO]:
-                    return
-            else:
-                os.close(fd)
-
-            # Resolve a major:minor to a /dev/foo
-            path = get_path(major_minor, device_name)
-            if path:
-                if parent:
-                    partition_number = int(re.search("(\d+)$", device_name).group(1))
-                else:
-                    partition_number = None
-
-                block_device_nodes[major_minor] = self._device_node(major_minor, path, size, parent, partition_number)
-                node_block_devices[path] = major_minor
-
-            return major_minor
-
-        for dev_dir in glob.glob("/sys/block/*"):
-            major_minor = parse_block_dir(dev_dir)
-
-            partitions = glob.glob(os.path.join(dev_dir, "*/dev"))
-            for p in partitions:
-                parse_block_dir(os.path.split(p)[0], parent = major_minor)
-
-        # Finally create the normalized maps for /dev to /dev/disk/by-path & /dev/disk/by-id
-        # and then /dev/disk/by-path & /dev/disk/by-id to /dev/mapper
-        ndp.add_normalized_list(dev_nodes, by_path_nodes)
-        ndp.add_normalized_list(dev_nodes, by_id_nodes)
-        ndp.add_normalized_list(by_path_nodes, mapper_devs)
-        ndp.add_normalized_list(by_id_nodes, mapper_devs)
-
-        return block_device_nodes, node_block_devices
-
+        return pipe(self.block_device_nodes.itervalues(),
+                    cmapcat(build_paths), dict)
 
     @classmethod
     def quick_scan(cls):
-        """ Return a very quick list of block devices from a number of sources so we can quickly see changes. """
-        blocks = []
-
-        for path in [cls.SYSBLOCKPATH, cls.MAPPERPATH, cls.DISKBYIDPATH, cls.DISKBYPATHPATH]:
-            blocks.extend(os.listdir(path))
-
-        return blocks
+        """
+            Return a very quick list of block devices from
+            a number of sources so we can quickly see changes.
+        """
+        return pipe(fetch_device_list(), cmapcat(getter("paths")), sorted)

--- a/chroma-agent/chroma_agent/device_plugins/linux_components/mdraid.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/mdraid.py
@@ -2,10 +2,9 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-
 import re
+import os
 
-from chroma_agent.device_plugins.linux_components.block_devices import BlockDevices
 from chroma_agent.lib.shell import AgentShell
 from chroma_agent.log import console_log
 from iml_common.lib.exception_sandbox import exceptionSandBox
@@ -13,6 +12,7 @@ from iml_common.lib.exception_sandbox import exceptionSandBox
 
 class MdRaid(object):
     """ Reads /proc/mdstat """
+    MDRAIDPATH = os.path.join('/dev', 'md')
 
     def __init__(self, block_devices):
         self.block_devices = block_devices
@@ -24,15 +24,19 @@ class MdRaid(object):
     @exceptionSandBox(console_log, [])
     def _get_md(self):
         try:
-            matches = re.finditer("^(md\d+) : active", open('/proc/mdstat').read().strip(), flags = re.MULTILINE)
-            dev_md_nodes = self.block_devices.find_block_devs(BlockDevices.MDRAIDPATH)
+            matches = re.finditer(
+                "^(md\d+) : active",
+                open('/proc/mdstat').read().strip(),
+                flags=re.MULTILINE)
+            dev_md_nodes = self.block_devices.find_block_devs(self.MDRAIDPATH)
 
             devs = []
             for match in matches:
                 # e.g. md0
                 device_name = match.group(1)
                 device_path = "/dev/%s" % device_name
-                device_major_minor = self.block_devices.path_to_major_minor(device_path)
+                device_major_minor = self.block_devices.path_to_major_minor(
+                    device_path)
 
                 # Defensive, but perhaps the md device doesn't show up as disk/by-id in which case we can't use it
                 try:
@@ -41,9 +45,17 @@ class MdRaid(object):
                     continue
 
                 try:
-                    detail = AgentShell.try_run(['mdadm', '--brief', '--detail', '--verbose', device_path])
-                    device_uuid = re.search("UUID=(.*)[ \\n]", detail.strip(), flags = re.MULTILINE).group(1)
-                    device_list_csv = re.search("^\s+devices=(.*)$", detail.strip(), flags = re.MULTILINE).group(1)
+                    detail = AgentShell.try_run([
+                        'mdadm', '--brief', '--detail', '--verbose',
+                        device_path
+                    ])
+                    device_uuid = re.search(
+                        "UUID=(.*)[ \\n]", detail.strip(),
+                        flags=re.MULTILINE).group(1)
+                    device_list_csv = re.search(
+                        "^\s+devices=(.*)$",
+                        detail.strip(),
+                        flags=re.MULTILINE).group(1)
                     device_list = device_list_csv.split(",")
 
                     devs.append({
@@ -51,10 +63,11 @@ class MdRaid(object):
                         "path": device_path,
                         "mm": device_major_minor,
                         "device_paths": device_list
-                        })
+                    })
                 except OSError as os_error:
                     # mdadm doesn't exist, threw an error etc.
-                    console_log.debug("mdadm threw an exception '%s' " % os_error.strerror)
+                    console_log.debug(
+                        "mdadm threw an exception '%s' " % os_error.strerror)
 
             return devs
         except IOError:

--- a/chroma-agent/chroma_agent/device_plugins/linux_components/zfs.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/zfs.py
@@ -338,6 +338,7 @@ class ZfsDevices(object):
             name = pool['name']
             block_devices.block_device_nodes[pool['block_device']] = {'major_minor': pool['block_device'],
                                                                       'path': name,
+                                                                      'paths': [name],
                                                                       'serial_80': None,
                                                                       'serial_83': None,
                                                                       'size': pool['size'],
@@ -356,6 +357,7 @@ class ZfsDevices(object):
                 name = info['name']
                 block_devices.block_device_nodes[major_minor] = {'major_minor': major_minor,
                                                                  'path': name,
+                                                                 'paths': [name],
                                                                  'serial_80': None,
                                                                  'serial_83': None,
                                                                  'size': info['size'],

--- a/chroma-agent/chroma_agent/lib/normalize_device_path.py
+++ b/chroma-agent/chroma_agent/lib/normalize_device_path.py
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-
 import os
 import glob
 import re
@@ -10,7 +9,7 @@ import re
 MAPPERPATH = os.path.join('/dev', 'mapper')
 DISKBYIDPATH = os.path.join('/dev', 'disk', 'by-id')
 
-_normalize_device_table = {}
+_NORMALIZE_DEVICE_TABLE = {}
 
 
 def normalized_device_path(device_path):
@@ -18,21 +17,25 @@ def normalized_device_path(device_path):
 
     normalized_path = os.path.realpath(device_path)
 
-    # This checks we have a completely normalized path, perhaps the stack means our current
-    # normal path can actually be normalized further. So if the root to normalization takes multiple
+    # This checks we have a completely normalized path, perhaps the
+    # stack means our current normal path can actually be normalized further.
+    # So if the root to normalization takes multiple
     # steps this will deal with it
     # So if /dev/sdx normalizes to /dev/mmapper/special-device
-    # but /dev/mmapper/special-device normalizes to /dev/md/mdraid1
-    # /dev/sdx will normalize to /dev/md/mdraid1
+    # and /dev/mmapper/special-device normalizes to /dev/md/mdraid1,
+    # then /dev/sdx will normalize to /dev/md/mdraid1
 
-    # As an additional measure to detect circular references such as A->B->C->A in
-    # this case we don't know which is the normalized value so just drop out once
+    # As an additional measure to detect circular references
+    # such as A->B->C->A in
+    # this case we don't know which is the
+    # normalized value so just drop out once
     # it repeats.
     visited = set()
 
-    while (normalized_path not in visited) and (normalized_path in _normalize_device_table):
+    while (normalized_path not in visited) and (
+            normalized_path in _NORMALIZE_DEVICE_TABLE):
         visited.add(normalized_path)
-        normalized_path = _normalize_device_table[normalized_path]
+        normalized_path = _NORMALIZE_DEVICE_TABLE[normalized_path]
 
     return normalized_path
 
@@ -40,7 +43,8 @@ def normalized_device_path(device_path):
 def find_normalized_start(device_fullpath):
     '''
     :param device_path: The device_path being search for
-    :return: Given /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333 returns
+    :return: Given /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333
+             returns
              /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333
              /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333-part1
              /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_WD-WMAP3333333-part9
@@ -49,13 +53,16 @@ def find_normalized_start(device_fullpath):
 
     _prime_normalized_paths()
 
-    values = [value for value in _normalize_device_table.values() if value.startswith(device_fullpath)]
+    values = [
+        value for value in _NORMALIZE_DEVICE_TABLE.values()
+        if value.startswith(device_fullpath)
+    ]
 
     return values
 
 
 def _prime_normalized_paths():
-    if _normalize_device_table == {}:
+    if _NORMALIZE_DEVICE_TABLE == {}:
         lookup_paths = ["%s/*" % DISKBYIDPATH, "%s/*" % MAPPERPATH]
 
         for path in lookup_paths:
@@ -73,22 +80,19 @@ def _prime_normalized_paths():
 
 def add_normalized_device(path, normalized_path):
     '''
-    Add an entry to the normalized path list, adding to often does no harm and adding something that
-    is not completely canonical does no harm either, because the search routine is recursive so if
+    Add an entry to the normalized path list, adding too often does no harm
+    and adding something that is not completely canonical does no harm either,
+    because the search routine is recursive so if
     A=>B and B=>C then A,B and C will all evaluate to the canonical value of C.
 
-    This routine does not add circular references, it is better to detect them in here than in the caller
+    This function does not add circular references, it is better to detect
+    them in here than in the caller
 
     :param path: device path
     :param normalized_path: canonical path
     :return: No return value
     '''
 
-    if (path != normalized_path):                           # Normalizing to itself makes no sense
-        _normalize_device_table[path] = normalized_path
-
-
-def add_normalized_list(raw_list, normalized_list):
-    for key, path in raw_list.items():
-        if key in normalized_list:
-            add_normalized_device(path, normalized_list[key])
+    # Normalizing to itself makes no sense
+    if path != normalized_path:
+        _NORMALIZE_DEVICE_TABLE[path] = normalized_path

--- a/chroma-agent/tests/device_plugins/linux/test_linux.py
+++ b/chroma-agent/tests/device_plugins/linux/test_linux.py
@@ -1,14 +1,13 @@
 import collections
 import json
 import errno
-import mock
 import os
+import mock
 from django.utils import unittest
 
 from chroma_agent.device_plugins.linux import DmsetupTable
 from chroma_agent.device_plugins.linux_components.block_devices import BlockDevices
 import chroma_agent.lib.normalize_device_path as ndp
-from iml_common.test.command_capture_testcase import CommandCaptureTestCase, CommandCaptureCommand
 
 
 class MockDmsetupTable(DmsetupTable):
@@ -17,8 +16,10 @@ class MockDmsetupTable(DmsetupTable):
         self.vgs = devices_data['vgs']
         self.mpaths = {}
         with mock.patch('chroma_agent.utils.BlkId', return_value={}):
-            with mock.patch('chroma_agent.device_plugins.linux_components.block_devices.BlockDevices._parse_sys_block',
-                            return_value=(devices_data['block_device_nodes'], devices_data['node_block_devices'])):
+            with mock.patch(
+                    'chroma_agent.device_plugins.linux_components.block_devices.BlockDevices._parse_sys_block',
+                    return_value=(devices_data['block_device_nodes'],
+                                  devices_data['node_block_devices'])):
                 self.block_devices = BlockDevices()
         self._parse_dm_table(dmsetup_data)
 
@@ -40,8 +41,11 @@ class LinuxAgentTests(unittest.TestCase):
 
         with mock.patch('__builtin__.open', mock_open):
             for path, normalized_path in normalized_values.items():
-                self.assertEqual(normalized_path, ndp.normalized_device_path(path),
-                                 "Normalized path failure %s != %s" % (normalized_path, ndp.normalized_device_path(path)))
+                self.assertEqual(normalized_path,
+                                 ndp.normalized_device_path(path),
+                                 "Normalized path failure %s != %s" %
+                                 (normalized_path,
+                                  ndp.normalized_device_path(path)))
 
 
 class DummyDataTestCase(LinuxAgentTests):
@@ -50,12 +54,14 @@ class DummyDataTestCase(LinuxAgentTests):
 
 
 class TestDmSetupParse(DummyDataTestCase):
-    def _test_dmsetup(self, devices_filename, dmsetup_filename, mpaths_filename, normalized_paths_filename):
+    def _test_dmsetup(self, devices_filename, dmsetup_filename,
+                      mpaths_filename, normalized_paths_filename):
         devices_data = json.loads(self.load(devices_filename))
         dmsetup_data = self.load(dmsetup_filename)
         actual_mpaths = MockDmsetupTable(dmsetup_data, devices_data).mpaths
         expected_mpaths = json.loads(self.load(mpaths_filename))
-        expected_normalized_paths = json.loads(self.load(normalized_paths_filename))
+        expected_normalized_paths = json.loads(
+            self.load(normalized_paths_filename))
 
         self.assertDictEqual(actual_mpaths, expected_mpaths)
         self.assertNormalizedPaths(expected_normalized_paths)
@@ -64,74 +70,132 @@ class TestDmSetupParse(DummyDataTestCase):
         """This is a regression test using data from a test/dev machine which includes LVs and multipath, all the data
            is just as it is when run through on Chroma 1.0.0.0: this really is a *regression* test rather than
            a correctness test.  The system from which this data was gathered ran CentOS 5.6"""
-        self._test_dmsetup('devices_1.json',
-                           'dmsetup_1.json',
-                           'mpaths_1.json',
+        self._test_dmsetup('devices_1.json', 'dmsetup_1.json', 'mpaths_1.json',
                            'normalized_1.json')
 
     def test_HYD_1383(self):
         """Minimal reproducer for HYD-1383.  The `dmsetup table` output is authentic, the other inputs are hand crafted to
            let it run through far enough to experience failure."""
-        self._test_dmsetup('devices_NTAP-12-min.json',
-                           'dmsetup_NTAP-12-min.json',
-                           'mpaths_NTAP-12-min.json',
-                           'normalized_NTAP-12-min.json')
+        self._test_dmsetup(
+            'devices_NTAP-12-min.json', 'dmsetup_NTAP-12-min.json',
+            'mpaths_NTAP-12-min.json', 'normalized_NTAP-12-min.json')
 
     def test_HYD_1385(self):
         """Minimal reproducer for HYD-1385.  The `dmsetup table` output is authentic, the other inputs are hand crafted to
            let it run through far enough to experience failure."""
-        self._test_dmsetup('devices_HYD-1385.json',
-                           'dmsetup_HYD-1385.json',
-                           'mpaths_HYD-1385.json',
-                           'normalized_HYD-1385.json')
+        self._test_dmsetup('devices_HYD-1385.json', 'dmsetup_HYD-1385.json',
+                           'mpaths_HYD-1385.json', 'normalized_HYD-1385.json')
 
     def test_HYD_1390(self):
         """Minimal reproducer for HYD-1385.  The `dmsetup table` output is authentic, the other inputs are hand crafted to
            let it run through far enough to experience failure."""
-        self._test_dmsetup('devices_HYD-1390.json',
-                           'dmsetup_HYD-1390.json',
-                           'mpaths_HYD-1390.json',
-                           'normalized_HYD-1390.json')
+        self._test_dmsetup('devices_HYD-1390.json', 'dmsetup_HYD-1390.json',
+                           'mpaths_HYD-1390.json', 'normalized_HYD-1390.json')
 
 
-class TestBlockDevices(CommandCaptureTestCase):
+class TestBlockDevices(unittest.TestCase):
     def setUp(self):
         super(TestBlockDevices, self).setUp()
 
+        fixture = {
+            "/devices/pci0000:00/0000:00:0d.0/ata11/host10/target10:0:0/10:0:0:0/block/sdi":
+            {
+                "ACTION":
+                "add",
+                "MAJOR":
+                "8",
+                "MINOR":
+                "128",
+                "DEVLINKS":
+                "/dev/disk/by-id/ata-VBOX_HARDDISK_VB94952694-0a23e192 /dev/disk/by-label/fs-OST0006 /dev/disk/by-path/pci-0000:00:0d.0-ata-9.0 /dev/disk/by-uuid/f21688ec-5bde-44a5-9ace-c7c4b18a20f5",
+                "PATHS": [
+                    "/dev/sdi",
+                    "/dev/disk/by-id/ata-VBOX_HARDDISK_VB94952694-0a23e192",
+                    "/dev/disk/by-label/fs-OST0006",
+                    "/dev/disk/by-path/pci-0000:00:0d.0-ata-9.0",
+                    "/dev/disk/by-uuid/f21688ec-5bde-44a5-9ace-c7c4b18a20f5"
+                ],
+                "DEVNAME":
+                "/dev/sdi",
+                "DEVPATH":
+                "/devices/pci0000:00/0000:00:0d.0/ata11/host10/target10:0:0/10:0:0:0/block/sdi",
+                "DEVTYPE":
+                "disk",
+                "ID_VENDOR":
+                None,
+                "ID_MODEL":
+                "VBOX_HARDDISK",
+                "ID_SERIAL":
+                "VBOX_HARDDISK_VB94952694-0a23e192",
+                "ID_FS_TYPE":
+                "ext4",
+                "ID_PART_ENTRY_NUMBER":
+                None,
+                "IML_SIZE":
+                "10485760",
+                "IML_SCSI_80":
+                "SATA     VBOX HARDDISK   VB94952694-0a23e192",
+                "IML_SCSI_83":
+                "1ATA     VBOX HARDDISK                           VB94952694-0a23e192",
+                "IML_IS_RO":
+                False
+            }
+        }
+
         with mock.patch('glob.glob', return_value=[]):
-            with mock.patch('chroma_agent.utils.BlkId', return_value={}):
+            with mock.patch(
+                    'chroma_agent.device_plugins.linux_components.block_devices.scanner_cmd',
+                    return_value=fixture):
                 self.block_devices = BlockDevices()
 
-        mock.patch('os.path.isfile', self.mock_isfile).start()
         self.existing_files = []
 
         # Guaranteed cleanup with unittest2
         self.addCleanup(mock.patch.stopall)
 
-    def mock_isfile(self, file):
-        return file in self.existing_files
+    def test_block_device_nodes_parsing(self):
+        result = self.block_devices.block_device_nodes
 
-    def test_device_node_versions(self):
-        for scsi_id in ["/sbin/scsi_id", "/lib/udev/scsi_id"]:
-            # Check runs with correct scsi_id
-            self.existing_files = [scsi_id]
+        self.assertEqual(result, {
+            "8:128": {
+                "size":
+                5368709120,
+                "device_path":
+                "/devices/pci0000:00/0000:00:0d.0/ata11/host10/target10:0:0/10:0:0:0/block/sdi",
+                "major_minor":
+                "8:128",
+                "partition_number":
+                None,
+                "device_type":
+                "disk",
+                "path":
+                "/dev/disk/by-id/ata-VBOX_HARDDISK_VB94952694-0a23e192",
+                "filesystem_type":
+                "ext4",
+                "paths": [
+                    "/dev/disk/by-id/ata-VBOX_HARDDISK_VB94952694-0a23e192",
+                    "/dev/disk/by-path/pci-0000:00:0d.0-ata-9.0", "/dev/sdi",
+                    "/dev/disk/by-label/fs-OST0006",
+                    "/dev/disk/by-uuid/f21688ec-5bde-44a5-9ace-c7c4b18a20f5"
+                ],
+                "parent":
+                None,
+                "serial_83":
+                "1ATA     VBOX HARDDISK                           VB94952694-0a23e192",
+                "serial_80":
+                "SATA     VBOX HARDDISK   VB94952694-0a23e192",
+                "is_ro":
+                False
+            }
+        })
 
-            self.reset_command_capture()
-            self.add_commands(CommandCaptureCommand(((scsi_id, '-g', '-p', '0x80', '/dev/blop'))),
-                              CommandCaptureCommand(((scsi_id, '-g', '-p', '0x83', '/dev/blop'))))
+    def test_node_block_devices_parsing(self):
+        result = self.block_devices.node_block_devices
 
-            result = self.block_devices._device_node(1, "/dev/blop", 1, None, '1234')
-
-            self.assertRanAllCommandsInOrder()
-
-            self.assertEqual(result, {'parent': None,
-                                      'major_minor': 1,
-                                      'serial_83': '',
-                                      'serial_80': '',
-                                      'path': '/dev/blop',
-                                      'filesystem_type': None,
-                                      'partition_number': '1234',
-                                      'size': 1})
+        self.assertEqual(result, {
+            "/dev/disk/by-id/ata-VBOX_HARDDISK_VB94952694-0a23e192":
+            "8:128"
+        })
 
 
 class TestDevMajorMinor(LinuxAgentTests):
@@ -150,70 +214,29 @@ class TestDevMajorMinor(LinuxAgentTests):
 
     def setUp(self):
         super(TestDevMajorMinor, self).setUp()
-        self.stat_patcher = mock.patch('os.stat', self.mock_os_stat)
-        self.stat_patcher.start()
-        mock.patch('os.minor', lambda st_rdev: st_rdev * 4).start()
-        mock.patch('os.major', lambda st_rdev: st_rdev * 2).start()
-        mock.patch('stat.S_ISBLK', return_value=True).start()
-        mock.patch('chroma_agent.lib.shell.AgentShell.try_run').start()
-        mock.patch('chroma_agent.utils.BlkId', return_value={0: {'path': self.mock_devices.keys()[0],
-                                                                 'type': 'ext4'}}).start()
-        mock.patch('chroma_agent.device_plugins.linux_components.block_devices.BlockDevices._parse_sys_block',
-                   return_value=(None, None)).start()
+        mock.patch(
+            'chroma_agent.utils.BlkId',
+            return_value={
+                0: {
+                    'path': self.mock_devices.keys()[0],
+                    'type': 'ext4'
+                }
+            }).start()
+        mock.patch(
+            'chroma_agent.device_plugins.linux_components.block_devices.BlockDevices._parse_sys_block',
+            return_value=(None, None)).start()
         self.addCleanup(mock.patch.stopall)
         self.block_devices = BlockDevices()
-        self.block_devices.non_existent_paths = set([])
-
-    def test_dev_major_minor_path_exists(self):
-        """ After a successful attempt, path should be removed from no-retry list """
-        path = '/dev/disk/by-id/adisk'
-        self.block_devices.non_existent_paths.add(path)
-        device = self.block_devices._dev_major_minor(path)
-        self.assertNotIn(path, self.block_devices.non_existent_paths)
-        self.assertEqual(device, '12:24')
-
-    def test_dev_major_minor_path_doesnt_exist(self):
-        """ After un-successful attempts, path should be added to no-retry list """
-        path = '/dev/disk/by-id/idontexist'
-        device = self.block_devices._dev_major_minor(path)
-        self.assertIn(path, self.block_devices.non_existent_paths)
-        self.assertEqual(device, None)
-
-    def test_dev_major_minor_path_exists_retries(self):
-        """ With existing path, method only calls stat once """
-        path = '/dev/disk/by-id/adisk'
-        self.stat_patcher.stop()
-        mock_stat = mock.patch('os.stat', return_value=TestDevMajorMinor.mock_devices[path]).start()
-        self.block_devices._dev_major_minor(path)
-        self.assertEqual(mock_stat.call_count, 1)
-        self.assertNotIn(path, self.block_devices.non_existent_paths)
-
-    def test_dev_major_minor_path_retry_doesnt_exist_retries(self):
-        """
-        Test non-existent path retries specified amount, and is subsequently added to the no-retry list.
-        On the next attempt with the same path, there should be no retries.
-        """
-        path = '/dev/disk/by-id/idontexist'
-        self.stat_patcher.stop()
-        self.assertNotIn(path, self.block_devices.non_existent_paths)
-        mock_stat = mock.patch('os.stat').start()
-        mock_stat.side_effect = OSError(errno.ENOENT, 'No such file or directory.')
-        self.block_devices._dev_major_minor(path)
-        self.assertEqual(mock_stat.call_count, BlockDevices.MAXRETRIES)
-        self.assertIn(path, self.block_devices.non_existent_paths)
-        mock_stat.reset_mock()
-        self.block_devices._dev_major_minor(path)
-        self.assertEqual(mock_stat.call_count, 1)
-        self.assertIn(path, self.block_devices.non_existent_paths)
 
     def test_paths_to_major_minors_paths_exist(self):
         self.block_devices.node_block_devices = self.node_block_devices
-        devices = self.block_devices.paths_to_major_minors(['/dev/disk/by-id/adisk'])
+        devices = self.block_devices.paths_to_major_minors(
+            ['/dev/disk/by-id/adisk'])
         self.assertEqual(len(devices), 1)
         self.assertEqual(devices, ['12:24'])
 
     def test_paths_to_major_minors_a_path_doesnt_exist(self):
         self.block_devices.node_block_devices = self.node_block_devices
-        devices = self.block_devices.paths_to_major_minors(['/dev/disk/by-id/idontexist',
-                                                            '/dev/disk/by-id/adisk'])
+        devices = self.block_devices.paths_to_major_minors(
+            ['/dev/disk/by-id/idontexist', '/dev/disk/by-id/adisk'])
         self.assertEqual(devices, ['12:24'])


### PR DESCRIPTION
This patch integrates the device-scanner repo into the iml-agent. It is a replacement for the `BlockDevices` class and imperative lookup of devices.

Instead, a device map is held in a daemon, and updated whenever a udev event is received over a unix domain socket.

As a first pass, the BlockDevices class is updated to query state from the scanner so it is still polling (but quicker). The ultimate goal will be to move from a poll model to a push model which will necessitate further changes downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/306)
<!-- Reviewable:end -->
