### PR TITLE
Re-enable (and fix) test_corosync_reverse_dependencies in sim test suite

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_corosync.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_corosync.py
@@ -1,7 +1,7 @@
 
 import logging
 
-from django.utils.unittest import skip, skipIf
+from django.utils.unittest import skip
 
 from testconfig import config
 from tests.integration.core.chroma_integration_testcase import ChromaIntegrationTestCase
@@ -192,8 +192,6 @@ class TestCorosync(ChromaIntegrationTestCase):
         for server in self.server_configs:
             self.wait_for_assert(lambda: self.assertNoAlerts(server['resource_uri'], of_type='HostOfflineAlert'))
 
-    @skipIf(config.get('simulator', False), "Skip failure in order to land #244 ("
-                                            "https://github.com/intel-hpdd/intel-manager-for-lustre/issues/301)")
     def test_corosync_reverse_dependencies(self):
         filesystem_id = self.create_filesystem_standard(config['lustre_servers'][0:4])
 


### PR DESCRIPTION
_test_corosync.py:TestCorosync.test_corosync_reverse_dependencies_ disabled/skipped in sim test suite in order to get #244 landed. Investigate this failure and find a fix so it can be re-enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/301)
<!-- Reviewable:end -->
