### PR TITLE
Pin to Lustre 2.10.1 Release

### DIFF
--- a/chroma-manager/storage_server.repo
+++ b/chroma-manager/storage_server.repo
@@ -11,13 +11,13 @@ enabled_metadata=1
 
 [lustre]
 name=Lustre Server
-baseurl=https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
+baseurl=https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/server/
 enabled=1
 gpgcheck=0
 
 [lustre-client]
 name=Lustre Client
-baseurl=https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/x86_64/axis-build_type/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/
+baseurl=https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/client/
 enabled=1
 gpgcheck=0
 

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -109,11 +109,11 @@ set_defaults() {
         export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
-        BASE_URL="https://build.whamcloud.com/jobs-pub/lustre-b2_10/configurations/axis-arch/\\\$basearch/axis-build_type"
-        export LUSTRE_SERVER_URL="$BASE_URL/server/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
-        export LUSTRE_CLIENT_URL="$BASE_URL/client/axis-distro/el7/axis-ib_stack/inkernel/builds/26/archive/artifacts/"
+        BASE_URL="https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/"
+        export LUSTRE_SERVER_URL="$BASE_URL/server/"
+        export LUSTRE_CLIENT_URL="$BASE_URL/client/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_jobs-pub_lustre-b2_10_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_26_archive_artifacts_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_server.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_client.repo"
     fi
 } # end of set_defaults()

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -113,7 +113,7 @@ set_defaults() {
         export LUSTRE_SERVER_URL="$BASE_URL/server/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_server.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_client.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_server_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_client_.repo"
     fi
 } # end of set_defaults()


### PR DESCRIPTION
Lustre 2.10.1 is officially released. Switch from using
review builds to the official download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/313)
<!-- Reviewable:end -->
