### PR TITLE
Fix param for --all-logs in run_iml_diagnostics

### DIFF
--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -542,7 +542,7 @@ class RealRemoteOperations(RemoteOperations):
 
     def run_iml_diagnostics(self, server, verbose):
         return self._ssh_fqdn(server['fqdn'],
-                              "iml-diagnostics" + " --all_logs" if verbose else "",
+                              "iml-diagnostics" + " --all-logs" if verbose else "",
                               timeout=LONG_TEST_TIMEOUT)
 
     def inject_log_message(self, fqdn, message):


### PR DESCRIPTION
```run_iml_diagnostics``` is currently calling `iml-diagnostics` with the wrong flag, it should be a `-` instead of a `_`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/318)
<!-- Reviewable:end -->
