### PR TITLE
Don't allow spaces in the interface name

### DIFF
--- a/chroma-manager/tests/integration/core/clear_ha_el7.sh
+++ b/chroma-manager/tests/integration/core/clear_ha_el7.sh
@@ -8,7 +8,7 @@ systemctl disable pcsd pacemaker corosync
 # figure it out for ourselves if we can
 # otherwise the caller needs to have set it
 if [ -f /etc/corosync/corosync.conf ]; then
-    ring1_iface=$(ip route get "$(sed -ne '/ringnumber: 1/{s///;n;s/.*: //p}' /etc/corosync/corosync.conf)" | sed -ne 's/.* dev \(.*\)  *src.*/\1/p')
+    ring1_iface=$(ip route get "$(sed -ne '/ringnumber: 1/{s///;n;s/.*: //p}' /etc/corosync/corosync.conf)" | sed -ne 's/.* dev \([^ ]*\)  *src.*/\1/p')
 fi
 
 ifconfig "$ring1_iface" 0.0.0.0 down


### PR DESCRIPTION
Due to an overly-liberal RE, a trailing space was allowed
to be included in the interface name.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/320)
<!-- Reviewable:end -->
