### PR TITLE
only use force when prompted in the failure message

### DIFF
--- a/chroma-agent/chroma_agent/action_plugins/manage_node.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_node.py
@@ -9,13 +9,6 @@ from chroma_agent.lib.shell import AgentShell
 from chroma_agent.log import console_log
 from chroma_agent.device_plugins.action_runner import CallbackAfterResponse
 from chroma_agent.lib.pacemaker import PacemakerConfig
-from iml_common.blockdevices.blockdevice import BlockDevice
-from iml_common.lib import util
-from iml_common.lib.agent_rpc import agent_error
-from iml_common.lib.agent_rpc import agent_result_ok
-from chroma_agent.lib.agent_startup_functions import agent_daemon_startup_function
-from chroma_agent.lib.agent_teardown_functions import agent_daemon_teardown_function
-from chroma_agent import config
 
 
 def ssi(runlevel):
@@ -62,32 +55,4 @@ def reboot_server(at_time = "now"):
 
     raise CallbackAfterResponse(None, _reboot)
 
-
-# When the agent is run we want to allow block devices to do any initialization that they might need, this function
-# may also be called by the manager.
-@agent_daemon_startup_function()
-def initialise_block_device_drivers():
-    console_log.info("Initialising drivers for block device types")
-    for cls in util.all_subclasses(BlockDevice):
-        error = cls.initialise_driver(config.profile_managed)
-
-        if error:
-            return agent_error(error)
-
-    return agent_result_ok
-
-
-# When the agent is stopped we want to allow block devices to do any termination that they might need, this function
-# may also be called by the manager.
-@agent_daemon_teardown_function()
-def terminate_block_device_drivers():
-    console_log.info("Terminating drivers for block device types")
-    for cls in util.all_subclasses(BlockDevice):
-        error = cls.terminate_driver()
-
-        if error:
-            return agent_error(error)
-
-    return agent_result_ok
-
-ACTIONS = [reboot_server, shutdown_server, fail_node, stonith, initialise_block_device_drivers]
+ACTIONS = [reboot_server, shutdown_server, fail_node, stonith]

--- a/chroma-agent/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_targets.py
@@ -477,7 +477,11 @@ def import_target(device_type, path, pacemaker_ha_operation, validate_importable
     """
     blockdevice = BlockDevice(device_type, path)
 
-    error = blockdevice.import_(pacemaker_ha_operation)
+    error = blockdevice.import_(False)
+    if error:
+        if '-f' in error and pacemaker_ha_operation:
+            error = blockdevice.import_(True)
+
     if error:
         console_log.error("Error importing pool: '%s'" % error)
 

--- a/chroma-agent/tests/actions_plugins/test_plugins.py
+++ b/chroma-agent/tests/actions_plugins/test_plugins.py
@@ -2,6 +2,9 @@ from mock import patch
 
 from django.utils.unittest import TestCase
 from chroma_agent.plugin_manager import DevicePluginManager, ActionPluginManager
+from chroma_agent.lib.agent_teardown_functions import agent_daemon_teardown_functions
+from chroma_agent.lib.agent_startup_functions import agent_daemon_startup_functions
+from chroma_agent.action_plugins.device_plugin import initialise_block_device_drivers, terminate_block_device_drivers
 
 
 class TestDevicePlugins(TestCase):
@@ -15,6 +18,14 @@ class TestDevicePlugins(TestCase):
         with patch('chroma_agent.plugin_manager.EXCLUDED_PLUGINS', ['linux']):
             with patch.object(DevicePluginManager, '_plugins', {}):
                 self.assertTrue('linux' not in DevicePluginManager.get_plugins())
+
+    def test_initialise_block_device_drivers_called_at_startup(self):
+        """Test method is added to list of functions to run on daemon startup."""
+        self.assertTrue(initialise_block_device_drivers in agent_daemon_startup_functions)
+
+    def test_terminate_block_device_drivers_called_at_teardown(self):
+        """Test method is added to list of functions to run on daemon teardown."""
+        self.assertTrue(terminate_block_device_drivers in agent_daemon_teardown_functions)
 
 
 class TestActionPlugins(TestCase):

--- a/chroma-agent/tests/test_manage_node.py
+++ b/chroma-agent/tests/test_manage_node.py
@@ -1,8 +1,0 @@
-from chroma_agent.lib.agent_startup_functions import agent_daemon_startup_functions
-from chroma_agent.action_plugins.manage_node import initialise_block_device_drivers
-from tests.lib.agent_unit_testcase import AgentUnitTestCase
-
-
-class TestManagedNode(AgentUnitTestCase):
-    def test_initialise_block_device_drivers_called_at_started(self):
-        self.assertTrue(initialise_block_device_drivers in agent_daemon_startup_functions)

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
@@ -20,7 +20,7 @@ class TestBlockDeviceLvm(TestBlockDevice):
     # Create a lvm on the device.
     @property
     def prepare_device_commands(self):
-        return ["vgcreate %s %s; lvcreate --wipesignatures n -l 100%%FREE --name %s %s" % (self.vg_name,
+        return ["vgcreate %s %s; lvcreate --wipesignatures y -l 100%%FREE --name %s %s" % (self.vg_name,
                                                                                            self._device_path,
                                                                                            self.lv_name,
                                                                                            self.vg_name)]

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
@@ -20,7 +20,7 @@ class TestBlockDeviceLvm(TestBlockDevice):
     # Create a lvm on the device.
     @property
     def prepare_device_commands(self):
-        return ["vgcreate %s %s; lvcreate --wipesignatures y -l 100%%FREE --name %s %s" % (self.vg_name,
+        return ["vgcreate %s %s; lvcreate --wipesignatures n -l 100%%FREE --name %s %s" % (self.vg_name,
                                                                                            self._device_path,
                                                                                            self.lv_name,
                                                                                            self.vg_name)]


### PR DESCRIPTION
zpool force import should only be used when necessary. only use the force flag during a pacemaker operation after the initial import (without force) fails and returns a message indicating that the pool can be imported using the '-f' flag. This can occur when a host is fenced while having a pool imported and another host attempts to import that same pool.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/325)
<!-- Reviewable:end -->
