### PR TITLE
retry on 'no such pool' import error

### DIFF
--- a/chroma-agent/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_targets.py
@@ -481,6 +481,9 @@ def import_target(device_type, path, pacemaker_ha_operation, validate_importable
     if error:
         if '-f' in error and pacemaker_ha_operation:
             error = blockdevice.import_(True)
+        elif 'no such pool available' in error:
+            console_log.error("no such pool available. retrying (%s)" % error)
+            error = blockdevice.import_(False)
 
     if error:
         console_log.error("Error importing pool: '%s'" % error)


### PR DESCRIPTION
'no such pool available' failure occurs occasionally when trying to import zpool that should exist. Retry import once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/326)
<!-- Reviewable:end -->
