### PR TITLE
perform zpool labelclear in addition to zpool destroy -f to improve c…

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -958,7 +958,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                     imported_zpools.append(zfs_device)
                 except AssertionError:
                     # We could not import so if we are going to CZP_REMOVEZPOOLS then we might as well now try and
-                    # dd the disk to get rid of the thing, otherwise raise the error. This is a best effort approach.
+                    # clear the disk to get rid of zfs signatures. This is a best effort approach.
                     if action & self.CZP_REMOVEZPOOLS:
                         self.execute_simultaneous_commands(zfs_device.clear_device_commands([zfs_device.device_path]),
                                                            [server['fqdn'] for server in test_servers],

--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -962,12 +962,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                     if action & self.CZP_REMOVEZPOOLS:
                         self.execute_simultaneous_commands(zfs_device.clear_device_commands([zfs_device.device_path]),
                                                            [server['fqdn'] for server in test_servers],
-                                                           'force destroy zpool %s' % zfs_device,
-                                                           expected_return_code=None)
-
-                        self.execute_simultaneous_commands(zfs_device.clear_label_commands,
-                                                           [server['fqdn'] for server in test_servers],
-                                                           'clear zpool labels on %s' % zfs_device,
+                                                           'force clear zpool %s' % zfs_device,
                                                            expected_return_code=None)
 
                         [self.remote_operations.reset_server(server['fqdn']) for server in test_servers]

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -103,7 +103,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         # commands in clear_device_commands won't get to do all that they are
         # supposed to (eg, lvremove removing lvm metadata).
         for server in config['lustre_servers']:
-            self.dd_devices(server['nodename'])
+            self.wipe_devices(server['nodename'])
 
             self.remote_command(server['address'],
                                 'reboot',
@@ -211,12 +211,14 @@ class CreateLustreFilesystem(UtilityTestCase):
             server_name,
             "sed -i '/lustre/d' /etc/fstab")
 
-    def dd_devices(self, server_name):
+    def wipe_devices(self, server_name):
         lustre_server = self.get_lustre_server_by_name(server_name)
         for device in lustre_server['device_paths']:
-            self.remote_command(
-                server_name,
-                "dd if=/dev/zero of=%s bs=512 count=1" % device)
+            block_device = TestBlockDevice('linux', device)
+
+            self.execute_commands(block_device.destroy_commands,
+                                  server_name,
+                                  'wipe device %s' % device)
 
     def rename_device(self, device_old_path, device_new_path):
         for lustre_server in config['lustre_servers']:

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -89,7 +89,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         for server in config['lustre_servers']:
             self.remote_command(
                 server['address'],
-                'umount -t lustre -a'
+                'systemctl stop chroma-agent; umount -t lustre -a'
             )
 
             self.umount_devices(server['nodename'])

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -89,7 +89,8 @@ class CreateLustreFilesystem(UtilityTestCase):
         for server in config['lustre_servers']:
             self.remote_command(
                 server['address'],
-                'systemctl stop chroma-agent; umount -t lustre -a'
+                'systemctl stop chroma-agent; umount -t lustre -a',
+                expected_return_code=None
             )
 
             self.umount_devices(server['nodename'])

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
@@ -22,9 +22,8 @@ class TestBlockDeviceLinux(TestBlockDevice):
 
     @property
     def destroy_commands(self):
-        # Needless to say, we're not bothering to scrub the whole device, just enough
-        # that it doesn't look formatted any more.
-        return ['dd if=/dev/zero of=%s bs=4k count=1; sync' % self.device_path]
+        # Remove any filesystem signatures on the disk
+        return ['wipefs -a %s; sync' % self.device_path]
 
     def __str__(self):
         return '%s' % self.device_path

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
@@ -23,7 +23,7 @@ class TestBlockDeviceLinux(TestBlockDevice):
     @property
     def destroy_commands(self):
         # Remove any filesystem signatures on the disk
-        return ['wipefs -a %s; sync' % self.device_path]
+        return ['wipefs -t zfs %s; sync' % self.device_path, 'dd if=/dev/zero of=%s bs=4k count=1; sync' % self.device_path]
 
     def __str__(self):
         return '%s' % self.device_path

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -39,7 +39,7 @@ class TestBlockDeviceZfs(TestBlockDevice):
 
     @classmethod
     def clear_device_commands(cls, device_paths):
-        return ["if zpool list {0}; then zpool destroy {0}; zpool labelclear -f {0}; else exit 0; fi".format(
+        return ["if zpool list {0}; then zpool destroy {0}; zpool labelclear {0}; else exit 0; fi".format(
             TestBlockDeviceZfs('zfs', device_path).device_path) for device_path in device_paths]
 
     @property

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -39,8 +39,8 @@ class TestBlockDeviceZfs(TestBlockDevice):
 
     @classmethod
     def clear_device_commands(cls, device_paths):
-        return ["if zpool list %s; then zpool destroy -f %s; else exit 0; fi" % (TestBlockDeviceZfs('zfs', device_path).device_path,
-                                                                                 TestBlockDeviceZfs('zfs', device_path).device_path) for device_path in device_paths]
+        return ["if zpool list {0}; then zpool destroy -f {0}; zpool labelclear -f {0}; else exit 0; fi".format(
+            TestBlockDeviceZfs('zfs', device_path).device_path) for device_path in device_paths]
 
     @property
     def install_packages_commands(self):

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -83,9 +83,5 @@ class TestBlockDeviceZfs(TestBlockDevice):
 
         return ['zpool destroy %s' % self.device_path]
 
-    @property
-    def clear_label_commands(self):
-        return ['zpool labelclear -f %s' % self.device_path]
-
     def __str__(self):
         return 'zpool(%s)' % self.device_path

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -39,7 +39,7 @@ class TestBlockDeviceZfs(TestBlockDevice):
 
     @classmethod
     def clear_device_commands(cls, device_paths):
-        return ["if zpool list {0}; then zpool destroy {0}; zpool labelclear {0}; else exit 0; fi".format(
+        return ["if zpool list {0}; then zpool destroy {0}; zpool labelclear -f {0}; else exit 0; fi".format(
             TestBlockDeviceZfs('zfs', device_path).device_path) for device_path in device_paths]
 
     @property

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -39,7 +39,7 @@ class TestBlockDeviceZfs(TestBlockDevice):
 
     @classmethod
     def clear_device_commands(cls, device_paths):
-        return ["if zpool list {0}; then zpool destroy -f {0}; zpool labelclear -f {0}; else exit 0; fi".format(
+        return ["if zpool list {0}; then zpool destroy {0}; zpool labelclear -f {0}; else exit 0; fi".format(
             TestBlockDeviceZfs('zfs', device_path).device_path) for device_path in device_paths]
 
     @property


### PR DESCRIPTION
…leanup between efs tests. I think a good change would be to make sure that the "clear device commands" for zfs included both zpool destroy  && zpool labelclear. this would just make sure that the devices are properly nuked between tests and combining the two commands would be compatible between efs and ssi usage

Changes made to augment the use of dd with wipefs to remove zfs filesystem signatures as opposed to just those at the beginning of the disk. Also ensure that both SSI and EFS tests is the same method called to clear the disks which will improve consistency.

ensure agents stopped before device destroy
introducing wiping of zfs signatures in addition to dd between tests in device destroy
perform zpool labelclear after zpool destroy in clear device commands

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/329)
<!-- Reviewable:end -->
