### PR TITLE
cleanup files after uninstall

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -144,6 +144,9 @@ fi
 MOST_RECENT_KERNEL_VERSION=$(rpm -q kernel --qf "%{INSTALLTIME} %{VERSION}-%{RELEASE}.%{ARCH}\n" | sort -nr | sed -n -e '/_lustre/{s/.* //p;q}')
 grubby --set-default=/boot/vmlinuz-$MOST_RECENT_KERNEL_VERSION
 
+%postun
+rm -rf /var/lib/iml*
+
 %files -f base.files
 %defattr(-,root,root)
 %attr(0755,root,root)/etc/init.d/chroma-agent


### PR DESCRIPTION
clean /var/lib/iml* on uninstall as store not getting truncated up now when agent stops/starts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/336)
<!-- Reviewable:end -->
