### PR TITLE
Re-enable (and fix) test_managed_filesystem_with_failover_mgs in ssi test suite

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
@@ -38,9 +38,8 @@ class TestManagedFilesystemWithFailover(FailoverTestCaseMixin, StatsTestCaseMixi
         finally:
             self.remote_operations.unmount_filesystem(client, filesystem)
 
-        return (filesystem_id, volumes_expected_hosts_in_normal_state)
+        return filesystem_id, volumes_expected_hosts_in_normal_state
 
-    @skip('Temporarily disable so we can land #244 (https://github.com/intel-hpdd/intel-manager-for-lustre/issues/298)')
     def test_create_filesystem_with_failover_mgs(self):
 
         filesystem_id, volumes_expected_hosts_in_normal_state = self._test_create_filesystem_with_failover()


### PR DESCRIPTION
_test_managed_filesystem_with_failover.py:TestManagedFilesystemWithFailover.test_managed_filesystem_with_failover_mgs_ disabled/skipped in ssi test suite in order to get #244 landed. Investigate this failure and find a fix so it can be re-enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/298)
<!-- Reviewable:end -->
