### PR TITLE
Replace non-ascii symbol with (R)

### DIFF
--- a/chroma-agent/chroma_agent/fence_chroma.py
+++ b/chroma-agent/chroma_agent/fence_chroma.py
@@ -59,8 +59,8 @@ Arguments read from standard input take the form of:
 
     if ns.action == "metadata":
         print """<?xml version="1.0" ?>
-<resource-agent name="fence_chroma" shortdesc="Fence agent for Intel® Manager for Lustre* software Storage Servers">
-<longdesc>fence_chroma is an I/O Fencing agent which can be used with Intel® Manager for Lustre* software Storage Servers.</longdesc>
+<resource-agent name="fence_chroma" shortdesc="Fence agent for Intel(R) Manager for Lustre* software Storage Servers">
+<longdesc>fence_chroma is an I/O Fencing agent which can be used with Intel(R) Manager for Lustre* software Storage Servers.</longdesc>
 <vendor-url>http://www.intel.com</vendor-url>
 <parameters>
     <parameter name="port">


### PR DESCRIPTION
Fixes #345

Due to an error with pcs parsing the output of a fence-agent's
metadata when that metadata contains non-ascii characters, switch
the non-ascii form of "registered trademark" to (R).

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/348)
<!-- Reviewable:end -->
