### PR TITLE
Remove duplicate port argument from fence agent

### DIFF
--- a/chroma-agent/chroma_agent/fence_chroma.py
+++ b/chroma-agent/chroma_agent/fence_chroma.py
@@ -73,11 +73,6 @@ Arguments read from standard input take the form of:
         <content type="string" />
         <shortdesc lang="en">Fencing action (%s)</shortdesc>
     </parameter>
-    <parameter name="port" unique="0" required="1">
-        <getopt mixed="-H, --plug=&lt;id&gt;" />
-        <content type="string" />
-        <shortdesc lang="en">Storage Server (machine name) to fence</shortdesc>
-    </parameter>
 </parameters>
 <actions>
     <action name="reboot" />


### PR DESCRIPTION
Fixes #346

A duplicate port specification got added to the fence agent
unnecessarily.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/350)
<!-- Reviewable:end -->
