### PR TITLE
Fixup test same name

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_filesystem_same_name.py
@@ -91,23 +91,23 @@ class TestFilesystemSameNameHYD832(ChromaIntegrationTestCase):
         self.remote_operations.stop_agents(s['address']
                                            for s in self.TEST_SERVERS[:4])
         for pool in pools:
-            self.execute_simultaneous_commands(
+            self.execute_commands(
                 ['zpool import %s' % pool],
-                fqdns,
+                fqdns[0],
                 'import pool %s' % pool,
                 expected_return_code=None)
 
         for zpool_dataset in datasets:
-            self.execute_simultaneous_commands(
+            self.execute_commands(
                 ['zfs destroy %s' % zpool_dataset],
-                fqdns,
+                fqdns[0],
                 'destroy zfs dataset %s' % zpool_dataset,
                 expected_return_code=None)
 
         for pool in pools:
-            self.execute_simultaneous_commands(
+            self.execute_commands(
                 ['zpool export %s' % pool],
-                fqdns,
+                fqdns[0],
                 'export pool %s' % pool,
                 expected_return_code=None)
 


### PR DESCRIPTION
`test_same_name` is doing import / destroy / export on all servers at once.

It should only happen on the first server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/356)
<!-- Reviewable:end -->
