### PR TITLE
zpool parsing bug when scrub in status

### DIFF
--- a/chroma-agent/chroma_agent/device_plugins/linux_components/zfs.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/zfs.py
@@ -150,10 +150,10 @@ def get_zpools(active=True):
         return []
 
     transform_pools = compose(_parse_line,
-                              lambda x: clean_list(re.split('(\w+):[^/]', x)),
-                              lambda x: 'pool: ' + x)
+                              lambda x: clean_list(re.split(r'\n\s*(\w+):\s', x)),
+                              lambda x: '\npool: ' + x)
 
-    return map(transform_pools, clean_list(re.split('pool:\s+', out)))
+    return map(transform_pools, clean_list(re.split(r'pool:\s', out)))
 
 
 def _get_zpool_datasets(pool_name, drives):

--- a/chroma-agent/tests/data/zfs_example_data.py
+++ b/chroma-agent/tests/data/zfs_example_data.py
@@ -208,7 +208,7 @@ single_raidz2_unavail_pool_B = """   pool: zost04
 
 multiple_imported_pools_status = """  pool: zfsPool3
  state: ONLINE
-  scan: none requested
+  scan: scrub repaired 0 in 0h0m with 0 errors on Tue Apr 11 18:07:44 2017
 config:
 
         NAME        STATE     READ WRITE CKSUM

--- a/chroma-agent/tests/device_plugins/linux/test_zfs.py
+++ b/chroma-agent/tests/device_plugins/linux/test_zfs.py
@@ -125,7 +125,8 @@ class TestZfs(LinuxAgentTests, CommandCaptureTestCase):
         zpools = get_zpools()
 
         self.assertRanAllCommandsInOrder()
-        self.assertListEqual(['zfsPool3', 'zfsPool1'], [p['pool'] for p in zpools])
+        self.assertListEqual(['zfsPool3', 'zfsPool1'], [pool['pool'] for pool in zpools])
+        [self.assertListEqual(['errors', 'scan', 'devices', 'state', 'pool'], pool.keys()) for pool in zpools]
 
     def test_get_no_active_zpools(self):
         """ WHEN no active/imported zpools are output from 'zpool status' command THEN parser returns empty list """
@@ -145,7 +146,8 @@ class TestZfs(LinuxAgentTests, CommandCaptureTestCase):
         zpools = get_zpools(active=False)
 
         self.assertRanAllCommandsInOrder()
-        self.assertListEqual(['zfsPool1', 'zfsPool2', 'zfsPool3'], [p['pool'] for p in zpools])
+        self.assertListEqual(['zfsPool1', 'zfsPool2', 'zfsPool3'], [pool['pool'] for pool in zpools])
+        [self.assertListEqual(['devices', 'state', 'action', 'id', 'pool'], pool.keys()) for pool in zpools]
 
     def test_already_imported_zpool(self):
         """


### PR DESCRIPTION
It appears that there is a bug in `zpool import / status` parsing when a scrub has been performed (or any value matching `(\w+):[^/]`).

a completed scrub will contain a timestamp which will match the regex:

```
re.split('(\w+):[^/]', 'scrub repaired 0B in 0h0m with 0 errors on Sun Oct 22 15:25:35 2017')
Out[2]:
['scrub repaired 0B in 0h0m with 0 errors on Sun Oct 22 ',
 '15',
 '',
 '5',
 '5 2017']
```

Ideally we could use a parser-combinator for this output (which would be sensitive to point of match ), but for now we should avoid splitting on values with ':'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/358)
<!-- Reviewable:end -->
