### PR TITLE
Don't merge old bundles with new

### DIFF
--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -305,7 +305,7 @@ def _new_profiles(upgrade):
 def _old_bundles():
     bundles = {}
     log.debug("Bundles currently installed:")
-    for bundle_meta_path in glob.glob(os.path.join(BUNDLE_ROOT, "*/meta")):
+    for bundle_meta_path in glob.glob(os.path.join(BUNDLE_ROOT, "*/*/meta")):
         meta = json.load(open(bundle_meta_path))
 
         log.debug("{name}-{version}: {description}".format(
@@ -449,6 +449,7 @@ def _backup_repo(old_bundles, bundle, meta):
     # repos
     if os.path.exists(os.path.join(BUNDLE_ROOT, meta['name'])):
         for path in os.listdir(os.path.join(BUNDLE_ROOT, meta['name'])):
+            path = os.path.join(BUNDLE_ROOT, meta['name'], path)
             if os.path.isdir(path):
                 shutil.rmtree(path)
             else:
@@ -507,6 +508,15 @@ def _install_or_upgrade_bundles(old_bundles, new_bundles):
             # repo will already have been moved to backup location
             log.debug("Removing retired bundle %s" % meta['name'])
             _run(['chroma-config', 'bundle', 'delete', install_location])
+            # agents will still have the repo we just deleted configured
+            # and be getting errors trying to find the metadata
+            # create an empty repo for this retired bundle
+            try:
+                os.makedirs(install_location)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise SystemExit("Failed to create %s" % install_location)
+            _run(['createrepo', install_location])
 
 
 def _install_or_upgrade_profiles(new_profiles):

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -57,6 +57,7 @@ Requires: iml-supervisor-status
 Requires: iml-gui
 Requires: iml-srcmap-reverse
 Requires: iml-online-help
+Requires: createrepo
 Conflicts: chroma-agent
 Requires(post): selinux-policy-targeted
 Obsoletes: httpd


### PR DESCRIPTION
Fixes #360

There was a design committed to retire old bundles when upgrades
were done but this doesn't really work as designed since it
leaves agents pointing at repos that don't exist immediately
after the manager upgrade is completed.

Instead, empty the retired bundles but make them valid (but
empty) repos.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/365)
<!-- Reviewable:end -->
