### PR TITLE
Fix log sorting

### DIFF
--- a/chroma-manager/chroma_core/models/log.py
+++ b/chroma-manager/chroma_core/models/log.py
@@ -37,7 +37,7 @@ class MessageClass:
 class LogMessage(models.Model):
     class Meta:
         app_label = 'chroma_core'
-        ordering = ['id']
+        ordering = ['-datetime']
 
     datetime = models.DateTimeField()
     # Note: storing FQDN rather than ManagedHost ID because:

--- a/chroma-manager/tests/unit/chroma_api/test_log.py
+++ b/chroma-manager/tests/unit/chroma_api/test_log.py
@@ -36,7 +36,8 @@ class TestLogResource(ChromaApiTestCase):
         for client_key in ['filesystem_user', 'unauthenticated']:
             client = self.clients[client_key]
             log_entries = [log_entry['message'] for log_entry in self.deserialize(client.get('/api/log/'))['objects']]
-            self.assertListEqual(self.lustre_messages, log_entries)
+            xs = self.lustre_messages[::-1]
+            self.assertListEqual(xs, log_entries)
 
     def test_get_logs_all(self):
         """Verifies superusers and filesystem_administrators gets all log entries"""
@@ -44,4 +45,5 @@ class TestLogResource(ChromaApiTestCase):
         for client_key in ['filesystem_administrator', 'superuser']:
             client = self.clients[client_key]
             log_entries = [log_entry['message'] for log_entry in self.deserialize(client.get('/api/log/'))['objects']]
-            self.assertListEqual(self.messages, log_entries)
+            xs = self.messages[::-1]
+            self.assertListEqual(xs, log_entries)


### PR DESCRIPTION
 - #274
 - Changed the log sorting to be based off of "datetime" instead of "id"
 - Fixed tests: Reverse sorted lists to satisfy the assert compare list equal test.
 - One list is defined by the test, the 2nd list is returned from the api.

Signed-off-by: Peter Robinson <peter.timothy.robinson@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/366)
<!-- Reviewable:end -->
