### PR TITLE
Add browser conf

### DIFF
--- a/chroma-manager/MANIFEST.in
+++ b/chroma-manager/MANIFEST.in
@@ -4,6 +4,7 @@ include logrotate.cfg
 include chroma-manager.py
 include production_supervisord.conf
 include chroma-manager.conf.template
+include chroma-manager-browser.conf.template
 include mime.types
 include agent-bootstrap-script.template
 include chroma_core/fixtures/*

--- a/chroma-manager/chroma-manager-browser.conf.template
+++ b/chroma-manager/chroma-manager-browser.conf.template
@@ -1,0 +1,103 @@
+server {
+  listen {{HTTPS_FRONTEND_PORT}} ssl http2;
+  server_name @GUI_NAME@;
+
+  error_page 497 https://$http_host$request_uri;
+
+  include {{APP_PATH}}/mime.types;
+
+  ssl_certificate {{SSL_PATH}}/manager.crt;
+  ssl_certificate_key {{SSL_PATH}}/manager.pem;
+  ssl_trusted_certificate {{SSL_PATH}}/authority.crt;
+  ssl_client_certificate {{SSL_PATH}}/authority.crt;
+  ssl_verify_client optional;
+  ssl_protocols TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:!DH+3DES:!ADH:!AECDH:!RC4:!aNULL:!MD5';
+
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 180m;
+
+  gzip_comp_level 2;
+  
+  location /favicon.ico {
+    alias /usr/lib/iml-manager/iml-gui/intel.ico;
+  }
+
+  location ~ ^/$ {
+    return 301 https://$http_host/ui;
+  }
+
+  location /help {
+    alias /usr/lib/iml-manager/iml-online-help;
+
+    gzip on;
+    gzip_types text/plain text/xml text/css application/x-javascript application/javascript text/javascript application/json;
+
+    index index.html;
+  }
+
+  location /gui/node_modules/socket-worker/dist {
+    alias {{APP_PATH}}/ui-modules/node_modules/@iml/socket-worker/dist;
+
+    etag on;
+    expires 1y;
+    add_header Cache-Control "public";
+
+    gzip on;
+    gzip_types application/x-javascript application/javascript text/javascript;
+  }
+
+  location /gui {
+    alias /usr/lib/iml-manager/iml-gui;
+
+    etag on;
+    expires 1y;
+    add_header Cache-Control "public";
+    
+    gzip on;
+    gzip_types text/plain text/xml text/css application/x-javascript application/javascript text/javascript application/json;
+  }
+
+  location /old-gui {
+    alias {{APP_PATH}}/ui-modules/node_modules/@iml/old-gui/static;
+
+    etag on;
+    expires 1y;
+    add_header Cache-Control "public";
+
+    gzip on;
+    gzip_types text/plain text/xml text/css application/x-javascript application/javascript text/javascript application/json;
+  }
+
+  location /ui {
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass http://127.0.0.1:{{VIEW_SERVER_PORT}}/ui;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; ";
+
+    gzip on;
+  }
+  
+  location /socket.io {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass http://127.0.0.1:{{REALTIME_PORT}}/socket.io;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+  location /api {
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Server $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass http://127.0.0.1:{{HTTP_API_PORT}}/api;
+  }
+}
+

--- a/chroma-manager/chroma-manager.conf.template
+++ b/chroma-manager/chroma-manager.conf.template
@@ -12,7 +12,7 @@ server {
 }
 
 server {
-    listen {{HTTPS_FRONTEND_PORT}} ssl http2;
+    listen {{HTTPS_FRONTEND_PORT}} ssl http2 default_server;
 
     error_page 497 https://$http_host$request_uri;
 
@@ -34,10 +34,6 @@ server {
 
     gzip_comp_level 2;
 
-    location /favicon.ico {
-      alias /usr/lib/iml-manager/iml-gui/intel.ico;
-    }
-
     location /certificate/ {
         return 301 https://$http_host/certificate;
     }
@@ -49,80 +45,12 @@ server {
         add_header Content-disposition "attachment; filename=download.cer";
     }
 
-    location ~ ^/$ {
-        return 301 https://$http_host/ui;
-    }
-
-    location /help {
-        alias /usr/lib/iml-manager/iml-online-help;
-
-        gzip on;
-        gzip_types text/plain text/xml text/css application/x-javascript application/javascript text/javascript application/json;
-
-        index index.html;
-    }
-
-    location /gui/node_modules/socket-worker/dist {
-        alias {{APP_PATH}}/ui-modules/node_modules/@iml/socket-worker/dist;
-
-        etag on;
-        expires 1y;
-        add_header Cache-Control "public";
-
-        gzip on;
-        gzip_types application/x-javascript application/javascript text/javascript;
-    }
-
-    location /gui {
-        alias /usr/lib/iml-manager/iml-gui;
-
-        etag on;
-        expires 1y;
-        add_header Cache-Control "public";
-        
-        gzip on;
-        gzip_types text/plain text/xml text/css application/x-javascript application/javascript text/javascript application/json;
-    }
-
-    location /old-gui {
-        alias {{APP_PATH}}/ui-modules/node_modules/@iml/old-gui/static;
-
-        etag on;
-        expires 1y;
-        add_header Cache-Control "public";
-
-        gzip on;
-        gzip_types text/plain text/xml text/css application/x-javascript application/javascript text/javascript application/json;
-    }
-
-    location /ui {
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Server $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://127.0.0.1:{{VIEW_SERVER_PORT}}/ui;
-
-        add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; ";
-
-        gzip on;
-    }
-
     location /api {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass http://127.0.0.1:{{HTTP_API_PORT}}/api;
-    }
-
-    location /socket.io {
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://127.0.0.1:{{REALTIME_PORT}}/socket.io;
-
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 
     location /agent/register {

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -164,6 +164,7 @@ cp -a chroma-manager.py build/lib
 cp -a storage_server.repo build/lib
 cp -a production_supervisord.conf build/lib
 cp -a chroma-manager.conf.template build/lib
+cp -a chroma-manager-browser.conf.template build/lib
 cp -a mime.types build/lib
 cp -a agent-bootstrap-script.template build/lib
 
@@ -175,6 +176,7 @@ mv $RPM_BUILD_ROOT/%{python_sitelib}/* $RPM_BUILD_ROOT%{manager_root}
 mv $RPM_BUILD_ROOT%{manager_root}/*.egg-info $RPM_BUILD_ROOT/%{python_sitelib}
 mkdir -p $RPM_BUILD_ROOT/etc/{init,logrotate,nginx/conf}.d
 touch $RPM_BUILD_ROOT/etc/nginx/conf.d/chroma-manager.conf
+touch $RPM_BUILD_ROOT/etc/nginx/conf.d/chroma-manager-browser.conf
 cp %{SOURCE1} $RPM_BUILD_ROOT/etc/init.d/chroma-supervisor
 cp %{SOURCE2} $RPM_BUILD_ROOT/etc/init.d/chroma-host-discover
 mkdir -p $RPM_BUILD_ROOT/usr/share/man/man1
@@ -212,6 +214,8 @@ rm -rf $RPM_BUILD_ROOT
 %post
 %{__python} $RPM_BUILD_ROOT%{manager_root}/scripts/production_nginx.py \
     $RPM_BUILD_ROOT%{manager_root}/chroma-manager.conf.template > /etc/nginx/conf.d/chroma-manager.conf
+%{__python} $RPM_BUILD_ROOT%{manager_root}/scripts/production_nginx.py \
+    $RPM_BUILD_ROOT%{manager_root}/chroma-manager-browser.conf.template > /etc/nginx/conf.d/chroma-manager-browser.conf
 
 # Create chroma-config MAN Page
 makewhatis
@@ -330,6 +334,7 @@ fi
 %attr(0700,root,root)%{_bindir}/chroma-config
 %dir %attr(0755,nginx,nginx)%{manager_root}
 /etc/nginx/conf.d/chroma-manager.conf
+/etc/nginx/conf.d/chroma-manager-browser.conf
 %attr(0755,root,root)/etc/init.d/chroma-supervisor
 %attr(0755,root,root)/etc/init.d/chroma-host-discover
 %attr(0755,root,root)/usr/share/man/man1/chroma-config.1.gz
@@ -339,6 +344,7 @@ fi
 %{manager_root}/agent-bootstrap-script.template
 %{manager_root}/chroma-manager.py
 %{manager_root}/chroma-manager.conf.template
+%{manager_root}/chroma-manager-browser.conf.template
 %{manager_root}/mime.types
 %{manager_root}/ui-modules/node_modules/*
 %{manager_root}/chroma_help/*

--- a/chroma-manager/chroma_core/management/commands/nginx.py
+++ b/chroma-manager/chroma_core/management/commands/nginx.py
@@ -49,6 +49,9 @@ class Command(BaseCommand):
         NGINX_CONF_TEMPLATE = join_site_root("nginx.conf.template")
         NGINX_CONF = join_nginx_dir("nginx.conf")
 
+        CHROMA_MANAGER_BROWSER_CONF_TEMPLATE = join_site_root("chroma-manager-browser.conf.template")
+        CHROMA_MANAGER_BROWSER_CONF = join_nginx_dir("chroma-manager-browser.conf")
+
         CHROMA_MANAGER_CONF_TEMPLATE = join_site_root("chroma-manager.conf.template")
         CHROMA_MANAGER_CONF = join_nginx_dir("chroma-manager.conf")
 
@@ -73,5 +76,6 @@ class Command(BaseCommand):
 
         write_conf(NGINX_CONF_TEMPLATE, NGINX_CONF)
         write_conf(CHROMA_MANAGER_CONF_TEMPLATE, CHROMA_MANAGER_CONF)
+        write_conf(CHROMA_MANAGER_BROWSER_CONF_TEMPLATE, CHROMA_MANAGER_BROWSER_CONF)
 
         print " ".join([self._nginx_path, "-c", NGINX_CONF])

--- a/chroma-manager/nginx.conf.template
+++ b/chroma-manager/nginx.conf.template
@@ -30,4 +30,5 @@ http {
     keepalive_timeout  65;
 
     include {{var}}/chroma-manager.conf;
+    include {{var}}/chroma-manager-browser.conf;
 }

--- a/chroma-manager/setup.py
+++ b/chroma-manager/setup.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-
 from setuptools import setup, find_packages, findall
 from scm_version import PACKAGE_VERSION
 from re import sub
@@ -14,37 +13,42 @@ excludes = [
 ]
 
 setup(
-    name = 'chroma-manager',
-    version = PACKAGE_VERSION,
-    author = "Intel Corporation",
-    author_email = "hpdd-info@intel.com",
-    url = 'http://lustre.intel.com/',
-    license = 'Proprietary',
-    description = 'The Intel® Manager for Lustre* software Monitoring and Administration Interface',
-    long_description = open('README.txt').read(),
-    packages = find_packages(exclude=excludes) + [''],
+    name='chroma-manager',
+    version=PACKAGE_VERSION,
+    author="Intel Corporation",
+    author_email="hpdd-info@intel.com",
+    url='http://lustre.intel.com/',
+    license='Proprietary',
+    description=
+    'The Intel® Manager for Lustre* software Monitoring and Administration Interface',
+    long_description=open('README.txt').read(),
+    packages=find_packages(exclude=excludes) + [''],
     # include_package_data would be far more convenient, but the top-level
     # package confuses setuptools. As a ridiculous hackaround, we'll game
     # things by prepending a dot to top-level datafiles (which implies
     # file creation/cleanup in the Makefile) to deal with the fact
     # that setuptools wants to strip the first character off the filename.
-    package_data = {
-        '': [".chroma-manager.py", ".production_supervisord.conf",
-             ".storage_server.repo",
-             ".chroma-manager.conf.template", ".mime.types"],
+    package_data={
+        '': [
+            ".chroma-manager.py", ".production_supervisord.conf",
+            ".storage_server.repo", ".chroma-manager.conf.template",
+            ".chroma-manager-browser.conf.template", ".mime.types"
+        ],
         'chroma_core': ["fixtures/default_power_types.json"],
         'polymorphic': ["COPYING"],
-        'tests': ["integration/run_tests",
-                  "integration/*/*.json",
-                  "sample_data/*",
-                  "integration/core/clear_ha_el?.sh"],
-        'ui-modules': [sub(r'^ui-modules/', '', x) for x in findall('ui-modules/node_modules/')]
+        'tests': [
+            "integration/run_tests", "integration/*/*.json", "sample_data/*",
+            "integration/core/clear_ha_el?.sh"
+        ],
+        'ui-modules': [
+            sub(r'^ui-modules/', '', x)
+            for x in findall('ui-modules/node_modules/')
+        ]
     },
-    scripts = ["chroma-host-discover"],
-    entry_points = {
+    scripts=["chroma-host-discover"],
+    entry_points={
         'console_scripts': [
             'chroma-config = chroma_core.lib.service_config:chroma_config',
             'chroma = chroma_cli.main:standard_cli'
         ]
-    }
-)
+    })


### PR DESCRIPTION
Background

In HYD-6955, we saw that Chrome will be removing support for SHA-1.
These types of changes are likely in the browser space and we may not need to update the agent crypto for all of them.
Additionally, some sites may wish to have a non self-signed cert. Currently it's difficult to change certs for a site that has deployed their agents.

Solution
Implement a separate conf for the browser. This conf will take it's own server_name. By doing this, we can serve different certs for the browser and the rest of the app.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/367)
<!-- Reviewable:end -->
