### PR TITLE
Replace single-server URL with redirecting URL

### DIFF
--- a/chroma-manager/storage_server.repo
+++ b/chroma-manager/storage_server.repo
@@ -45,4 +45,5 @@ failovermethod=priority
 enabled=1
 gpgcheck=1
 #gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
-gpgkey=https://muug.ca/mirror/fedora-epel/RPM-GPG-KEY-EPEL-7
+gpgkey=https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+


### PR DESCRIPTION
Instead of using a single server specific URL for the
GPG key location, use a redirecting URL for resiliency.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/376)
<!-- Reviewable:end -->
