### PR TITLE
Move resetting of Vagrant cluster to provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,10 @@ install_production: reset_cluster
 # To run a specific test:
 # make TESTS=tests/integration/shared_storage_configuration/test_example_api_client.py:TestExampleApiClient.test_login ssi_tests
 # set NOSE_ARGS="-x" to stop on the first failure
-ssi_tests: reset_cluster
+ssi_tests:
 	chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main $@
 
-efs_tests: reset_cluster
+efs_tests:
 	pdsh -R ssh -l root -S -w vm[5-9] "echo \"options lnet networks=\\\"tcp(eth1)\\\"\" > /etc/modprobe.d/iml_lnet_module_parameters.conf; systemctl disable firewalld; systemctl stop firewalld"
 	chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main $@
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |config|
 	# use the "images" storage pool
 	config.vm.provider :libvirt do |libvirt, override|
 		override.vm.box = "centos/7"
+                # set to distro version desired for test
+                override.vm.box_version = "> 1708, < 9999"
 		libvirt.storage_pool_name = "images"
 		libvirt.memory = 2048
 		libvirt.cpus = 2

--- a/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
+++ b/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
@@ -6,8 +6,8 @@ if $JENKINS; then
     BUILD_JOB_BUILD_NUMBER=${BUILD_JOB_BUILD_NUMBER:?"Need to set BUILD_JOB_BUILD_NUMBER"}
     IEEL_VERSION=${IEEL_VERSION:?"Need to set IEEL_VERSION"}
     TEST_DISTRO_NAME=${TEST_DISTRO_NAME:?"Need to set TEST_DISTRO_NAME"}
-    TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:?"Need to set TEST_DISTRO_VERSION"}
 fi
+TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:?"Need to set TEST_DISTRO_VERSION"}
 CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:?"Need to specify a CLUSTER_CONFIG_TEMPLATE path"}
 CLUSTER_CONFIG=${CLUSTER_CONFIG:?"Need to specify a CLUSTER_CONFIG path to output the test json after provisioning"}
 
@@ -47,6 +47,16 @@ if $JENKINS; then
         exit 1
     fi
 else
+    # set the correct Vagrant box for the
+    # TEST_DISTRO_VERSION
+    declare -A vagrant_centos_boxes=( [7.2]=1511
+                                      [7.3]=1611
+                                      [7.4]=1708
+                                      [7.5]=9999 )
+
+    sed -i -e "/override\.vm\.box_version/s/> [0-9][0-9]*, *< *[0-9][0-9]*/> ${vagrant_centos_boxes[$TEST_DISTRO_VERSION]}, < ${vagrant_centos_boxes[$(echo "$TEST_DISTRO_VERSION+.1" | bc)]}/" Vagrantfile
+
+    make reset_cluster
     cp provisioner_output-vagrant-${MAKE_TARGET%_tests}.json provisioner_output.json
 fi
 


### PR DESCRIPTION
So that testing in Vagrant aligns better with testing in CI.

Also, make sure the Vagrant box is at the required version.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/389)
<!-- Reviewable:end -->
