### PR TITLE
Run upgrade test in Vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,10 @@ install_production: reset_cluster
 # To run a specific test:
 # make TESTS=tests/integration/shared_storage_configuration/test_example_api_client.py:TestExampleApiClient.test_login ssi_tests
 # set NOSE_ARGS="-x" to stop on the first failure
-ssi_tests: reset_cluster
+ssi_tests:
 	chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main $@
 
-efs_tests: reset_cluster
+efs_tests:
 	pdsh -R ssh -l root -S -w vm[5-9] "echo \"options lnet networks=\\\"tcp(eth1)\\\"\" > /etc/modprobe.d/iml_lnet_module_parameters.conf; systemctl disable firewalld; systemctl stop firewalld"
 	chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main $@
 

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,9 @@ install_production: reset_cluster
 ssi_tests:
 	chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main $@
 
+upgrade_tests:
+	chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main $@
+
 efs_tests:
 	pdsh -R ssh -l root -S -w vm[5-9] "echo \"options lnet networks=\\\"tcp(eth1)\\\"\" > /etc/modprobe.d/iml_lnet_module_parameters.conf; systemctl disable firewalld; systemctl stop firewalld"
 	chroma-manager/tests/framework/integration/existing_filesystem_configuration/jenkins_steps/main $@

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |config|
 	# use the "images" storage pool
 	config.vm.provider :libvirt do |libvirt, override|
 		override.vm.box = "centos/7"
+                # set to distro version desired for test
+                override.vm.box_version = "> 1708, < 9999"
 		libvirt.storage_pool_name = "images"
 		libvirt.memory = 2048
 		libvirt.cpus = 2

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/cluster_setup
@@ -30,13 +30,27 @@ if [ ${PIPESTATUS[0]} != 0 ]; then
 fi
 
 # Install and setup integration tests on integration test runner
-scp $CLUSTER_CONFIG root@$TEST_RUNNER:/root/cluster_cfg.json
+if ! $JENKINS; then
+    CMIT=$(ls chroma-manager/dist/chroma-manager-integration-tests-*.x86_64.rpm)
+fi
+scp $CMIT $CLUSTER_CONFIG root@$TEST_RUNNER:/root/
 ssh root@$TEST_RUNNER <<EOF
 exec 2>&1; set -xe
+if $JENKINS; then
+    yum --disablerepo=\* --enablerepo=chroma makecache
+    CMIT=chroma-manager-integration-tests
+else
+    CMIT=/root/${CMIT##*/}
+fi
+
 # set up required repos
 yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/$COPR_OWNER/$COPR_PROJECT/repo/epel-7/$COPR_OWNER-$COPR_PROJECT-epel-7.repo
 yum -y install epel-release
-yum -y install chroma-manager-integration-tests
+
+if ! $PROXY yum -y install \$CMIT; then
+    $PROXY yum clean all
+    $PROXY yum -y install \$CMIT
+fi
 
 if $USE_FENCE_XVM; then
     # make sure the host has fence_virtd installed and configured

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/jenkins_steps/main
@@ -6,12 +6,16 @@
 set_defaults true
 check_for_autopass
 
+if ! $JENKINS; then
+    CHROMA_DIR="$PWD"
+fi
 export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"$CHROMA_DIR/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json"}
 CURRENT_IEEL_VERSION=$(make -f include/Makefile.version .ieel_version 2>/dev/null) || true
-SLAVE=${slave:?"Need to set slave"}
 
-cd $WORKSPACE
-curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz "$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz"
+if $JENKINS; then
+    cd $WORKSPACE
+    curl -f -k -o $SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION-current.tar.gz "$JOB_URL/$SHORT_ARCHIVE_NAME-$CURRENT_IEEL_VERSION.tar.gz"
+fi
 
 # Gather logs from nodes and release the cluster at exit
 trap "set +e

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -158,8 +158,16 @@ if [ -f ~/storage_server.repo ]; then
 fi
 
 # Install and setup manager
-scp $STORAGE_SERVER_REPO "$ARCHIVE_NAME" "$CHROMA_DIR"/chroma-manager/tests/utils/upgrade.exp root@"$CHROMA_MANAGER":/tmp
-ssh root@$CHROMA_MANAGER "#don't do this, it hangs the ssh up, when used with expect, for some reason: exec 2>&1
+ARCHIVE_SUFFIX=.tar.gz
+if $JENKINS; then
+    ARCHIVE_PATH=.
+    ARCHIVE_SUFFIX="-current$ARCHIVE_SUFFIX"
+else
+    ARCHIVE_PATH=chroma-bundles
+    ARCHIVE_NAME=$SHORT_ARCHIVE_NAME-$IEEL_VERSION.tar.gz
+fi
+scp $STORAGE_SERVER_REPO "$ARCHIVE_PATH/$ARCHIVE_NAME" "$CHROMA_DIR"/chroma-manager/tests/utils/upgrade.exp root@"$CHROMA_MANAGER":/tmp
+ssh root@"$CHROMA_MANAGER" "#don't do this, it hangs the ssh up, when used with expect, for some reason: exec 2>&1
 set -ex
 existing_IML_version=\$(rpm -q --qf \"%{VERSION}-%{RELEASE}\n\" chroma-manager)
 
@@ -171,7 +179,7 @@ mv upgrade.exp $UPGRADE_INSTALL_DIR/upgrade.exp
 
 cd $UPGRADE_INSTALL_DIR
 tar xzvf $ARCHIVE_NAME
-cd $(basename $ARCHIVE_NAME -current.tar.gz)
+cd \"${ARCHIVE_NAME%$ARCHIVE_SUFFIX}\"
 
 # Install from the installation package
 echo \"First without access to YUM repos\"

--- a/chroma-manager/tests/framework/integration/upgrade_os/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/upgrade_os/jenkins_steps/main
@@ -7,7 +7,6 @@ set_defaults true
 check_for_autopass
 
 export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"chroma/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json"}
-SLAVE=${slave:?"Need to set slave"}
 
 cd $WORKSPACE
 curl -f -k -O "$JOB_URL/chroma-bundles/$ARCHIVE_NAME"

--- a/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
+++ b/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
@@ -6,8 +6,8 @@ if $JENKINS; then
     BUILD_JOB_BUILD_NUMBER=${BUILD_JOB_BUILD_NUMBER:?"Need to set BUILD_JOB_BUILD_NUMBER"}
     IEEL_VERSION=${IEEL_VERSION:?"Need to set IEEL_VERSION"}
     TEST_DISTRO_NAME=${TEST_DISTRO_NAME:?"Need to set TEST_DISTRO_NAME"}
-    TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:?"Need to set TEST_DISTRO_VERSION"}
 fi
+TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:?"Need to set TEST_DISTRO_VERSION"}
 CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:?"Need to specify a CLUSTER_CONFIG_TEMPLATE path"}
 CLUSTER_CONFIG=${CLUSTER_CONFIG:?"Need to specify a CLUSTER_CONFIG path to output the test json after provisioning"}
 
@@ -47,6 +47,16 @@ if $JENKINS; then
         exit 1
     fi
 else
+    # set the correct Vagrant box for the
+    # TEST_DISTRO_VERSION
+    declare -A vagrant_centos_boxes=( [7.2]=1511
+                                      [7.3]=1611
+                                      [7.4]=1708
+                                      [7.5]=9999 )
+
+    sed -i -e "/override\.vm\.box_version/s/> [0-9][0-9]*, *< *[0-9][0-9]*/> ${vagrant_centos_boxes[$TEST_DISTRO_VERSION]}, < ${vagrant_centos_boxes[$(echo "$TEST_DISTRO_VERSION+.1" | bc)]}/" Vagrantfile
+
+    make reset_cluster
     cp provisioner_output-vagrant-${MAKE_TARGET%_tests}.json provisioner_output.json
 fi
 

--- a/provisioner_output-vagrant-upgrade.json
+++ b/provisioner_output-vagrant-upgrade.json
@@ -25,28 +25,24 @@
   "managed": true,
   "lustre_devices": [
     {
-      "backend_filesystem": "linux",
+      "backend_filesystem": "ldiskfs",
       "path_index": 0
     },
     {
-      "backend_filesystem": "linux",
+      "backend_filesystem": "ldiskfs",
       "path_index": 1
     },
     {
-      "backend_filesystem": "linux",
+      "backend_filesystem": "ldiskfs",
       "path_index": 2
     },
     {
-      "backend_filesystem": "linux",
+      "backend_filesystem": "ldiskfs",
       "path_index": 3
     },
     {
-      "backend_filesystem": "linux",
+      "backend_filesystem": "ldiskfs",
       "path_index": 4
-    },
-    {
-      "backend_filesystem": "linux",
-      "path_index": 5
     }
   ],
   "power_distribution_units": [
@@ -115,8 +111,7 @@
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target2",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target3",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target4",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target6"
+        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5"
       ],
       "corosync_config": {
         "mcast_port": "4242",
@@ -143,8 +138,7 @@
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target2",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target3",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target4",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target6"
+        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5"
       ],
       "corosync_config": {
         "mcast_port": "4242",
@@ -171,8 +165,7 @@
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target2",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target3",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target4",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target6"
+        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5"
       ],
       "corosync_config": {
         "mcast_port": "4244",
@@ -199,8 +192,7 @@
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target2",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target3",
         "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target4",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5",
-        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target6"
+        "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_target5"
       ],
       "corosync_config": {
         "mcast_port": "4244",


### PR DESCRIPTION
Upgrades need to start on EL 7.3:
- update the Vagrant file to use an EL 7.3 image
- need to automate this in some way for only upgrade testing
- probably as part of moving vagrant reset to provisioning

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/390)
<!-- Reviewable:end -->
