### PR TITLE
Nginx 1.12 fix

### DIFF
--- a/chroma-manager/chroma-manager.conf.template
+++ b/chroma-manager/chroma-manager.conf.template
@@ -1,6 +1,6 @@
 map $ssl_client_s_dn $ssl_client_s_dn_cn {
     default "";
-    ~/CN=(?<CN>[^/]+) $CN;
+    ~CN=(?<CN>[^,]+) $CN;
 }
 
 error_log syslog:server=unix:/dev/log;

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -103,13 +103,13 @@ Obsoletes: django-celery
 
 %if 0%{?rhel} < 7
 Requires: fence-agents-iml >= 3.1.5-48.wc1.el6.2
-Requires: nginx >= 1.10.1-1
+Requires: nginx >= 1.11.6
 %endif
 
 %if 0%{?rhel} > 6
 Requires: fence-agents
 Requires: fence-agents-virsh
-Requires: nginx >= 1:1.10.1-1
+Requires: nginx >= 1:1.11.6
 %endif
 
 %description


### PR DESCRIPTION
In nginx release 1.11.6 the variable $ssl_client_s_dn
had it's value format updated to meet an RFC spec.

https://github.com/nginx/nginx/commit/71c93a

Adjust our parsing to account for the new format and
require version >= 1.11.6 nginx.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/391)
<!-- Reviewable:end -->
