### PR TITLE
Use a local storage-server repo definition

### DIFF
--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/cluster_setup
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/cluster_setup
@@ -75,7 +75,12 @@ if $JENKINS; then
 else
     ARCHIVE_PATH=chroma-bundles
 fi
-scp $ARCHIVE_PATH/$ARCHIVE_NAME $CHROMA_DIR/chroma-manager/tests/utils/install.exp root@$CHROMA_MANAGER:/tmp
+
+if [ -f ~/storage_server.repo ]; then
+    STORAGE_SERVER_REPO=~/storage_server.repo
+fi
+
+scp $STORAGE_SERVER_REPO $ARCHIVE_PATH/$ARCHIVE_NAME $CHROMA_DIR/chroma-manager/tests/utils/install.exp root@$CHROMA_MANAGER:/tmp
 ssh root@$CHROMA_MANAGER "#don't do this, it hangs the ssh up, when used with expect, for some reason: exec 2>&1
 set -ex
 yum -y install expect pdsh
@@ -96,6 +101,11 @@ if ! expect ../install.exp $CHROMA_USER $CHROMA_EMAIL $CHROMA_PASS ${CHROMA_NTP_
     rc=\${PIPESTATUS[0]}
     cat /var/log/chroma/install.log
     exit \$rc
+fi
+
+# override /usr/share/chroma-manager/storage_server.repo
+if [ -f /tmp/storage_server.repo ]; then
+    cp /tmp/storage_server.repo /usr/share/chroma-manager/storage_server.repo
 fi
 
 cat <<\"EOF1\" > /usr/share/chroma-manager/local_settings.py

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
@@ -36,7 +36,13 @@ if $JENKINS; then
 else
     ARCHIVE_PATH=chroma-bundles
 fi
-scp $ARCHIVE_PATH/$ARCHIVE_NAME $CHROMA_DIR/chroma-manager/tests/utils/install.exp root@$CHROMA_MANAGER:/tmp
+
+if [ -f ~/storage_server.repo ]; then
+    STORAGE_SERVER_REPO=~/storage_server.repo
+fi
+
+# Install and setup manager
+scp $STORAGE_SERVER_REPO $ARCHIVE_PATH/$ARCHIVE_NAME $CHROMA_DIR/chroma-manager/tests/utils/install.exp root@$CHROMA_MANAGER:/tmp
 ssh root@$CHROMA_MANAGER "#don't do this, it hangs the ssh up, when used with expect, for some reason: exec 2>&1
 set -ex
 # install cman here to test that the fence-agents-iml package is being a
@@ -52,6 +58,11 @@ if ! expect ../install.exp $CHROMA_USER $CHROMA_EMAIL $CHROMA_PASS ${CHROMA_NTP_
     rc=\${PIPESTATUS[0]}
     cat /var/log/chroma/install.log
     exit \$rc
+fi
+
+# override /usr/share/chroma-manager/storage_server.repo
+if [ -f /tmp/storage_server.repo ]; then
+    cp /tmp/storage_server.repo /usr/share/chroma-manager/storage_server.repo
 fi
 
 cat <<\"EOF1\" > /usr/share/chroma-manager/local_settings.py


### PR DESCRIPTION
If available.

This allows a local storage server repo to override the default storage repo
in EFS and SSI tests.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/394)
<!-- Reviewable:end -->
