### PR TITLE
Limit partprobing to storage disks

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -121,9 +121,11 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         else:
             self.remote_operations = RealRemoteOperations(self)
 
+        storage_servers = [s for s in self.TEST_SERVERS
+                           if 'worker' not in s.get('profile', "")]
         if self.quick_setup is False:
             # Ensure that all servers are up and available
-            for server in self.TEST_SERVERS:
+            for server in storage_servers:
                 logger.info("Checking that %s is running and restarting if necessary..." % server['fqdn'])
                 self.remote_operations.await_server_boot(server['fqdn'], restart = True)
                 logger.info("%s is running" % server['fqdn'])
@@ -138,7 +140,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                 # Reset the manager via the API
                 self.wait_until_true(self.api_contactable)
                 self.api_force_clear()
-                self.remote_operations.clear_ha(self.TEST_SERVERS)
+                self.remote_operations.clear_ha(storage_servers)
                 self.remote_operations.clear_lnet_config(self.TEST_SERVERS)
 
             if config.get('managed'):
@@ -152,7 +154,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                 self.remote_operations.write_config(self.TEST_SERVERS)
 
                 # cleanup linux devices
-                self.cleanup_linux_devices(self.TEST_SERVERS)
+                self.cleanup_linux_devices(storage_servers)
 
                 self.cleanup_zpools()
                 self.create_zpools()
@@ -887,7 +889,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         return any(lustre_device['backend_filesystem'] == 'zfs' for lustre_device in config['lustre_devices'])
 
     def create_zpools(self):
-        xs = config['lustre_servers'][:4]
+        xs = self.config_servers
         server0 = xs[0]
         fqdns = [x['fqdn'] for x in xs]
 
@@ -908,7 +910,11 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                                       server0['fqdn'],
                                       'export zfs device %s' % zfs_device)
 
-            self.execute_simultaneous_commands(['partprobe', 'udevadm settle'], fqdns, 'sync partitions')
+                # only partprobe the devices we are cleaning, as we can get
+                # EBUSY for the root disk for example
+                self.execute_simultaneous_commands(['partprobe %s' %
+                                                    server0['orig_device_paths'][lustre_device['path_index']],
+                                                    'udevadm settle'], fqdns, 'sync partitions')
 
     def cleanup_zpools(self):
         if (self.simulator is not None) or (self.zfs_devices_exist() is False):
@@ -958,7 +964,10 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         self.execute_commands([wipe(x) for x in zfs_device_paths],
                               server0['fqdn'], 'wiping disks')
 
-        self.execute_simultaneous_commands(['partprobe', 'udevadm settle'], fqdns, 'sync partitions')
+        # only partprobe the devices we are cleaning, as we can get
+        # EBUSY for the root disk for example
+        self.execute_simultaneous_commands(['partprobe %s' % " ".join(zfs_device_paths),
+                                            'udevadm settle'], fqdns, 'sync partitions')
 
         [
             self.remote_operations.reset_server(
@@ -992,7 +1001,10 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         wipe_commands = map(cleanup_str, device_paths)
         self.execute_commands(wipe_commands, first_test_server['fqdn'], desc)
 
-        self.execute_simultaneous_commands(['partprobe', 'udevadm settle'], [
+        # only partprobe the devices we are cleaning, as we can get
+        # EBUSY for the root disk for example
+        self.execute_simultaneous_commands(['partprobe %s' % " ".join(device_paths),
+                                           'udevadm settle'], [
             server['fqdn'] for server in test_servers
         ], 'sync partitions')
 

--- a/chroma-manager/tests/integration/installation_and_upgrade/test_update_with_yum.py
+++ b/chroma-manager/tests/integration/installation_and_upgrade/test_update_with_yum.py
@@ -58,7 +58,8 @@ class TestYumUpdate(TestInstallationAndUpgrade):
     # something we can run to clear the storage targets since this
     # test class doesn't use setUp()
     def test_clean_linux_devices(self):
-        self.cleanup_linux_devices(self.TEST_SERVERS)
+        self.cleanup_linux_devices([s for s in self.TEST_SERVERS
+                                    if 'worker' not in s.get('profile', "")])
 
     def test_stop_before_update(self):
         # Stop the filesystem. Currently the GUI forces you to stop the filesystem before


### PR DESCRIPTION
Because we can get an EBUSY on the root disk when trying to
partprobe it.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/397)
<!-- Reviewable:end -->
