### PR TITLE
Boot CentOS nodes in Vagrant verbosely

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,6 +88,9 @@ __EOF
 	config.vm.provision "shell", inline: "systemctl enable firewalld"
 	config.vm.provision "shell", inline: "systemctl start firewalld"
 
+	# Verbose booting
+	config.vm.provision "shell", inline: "sed -ie 's/ rhgb quiet//' /boot/grub2/grub.cfg /etc/sysconfig/grub"
+
 	# The VMs will have IPv6 but no IPv6 connectivity so alter
 	# their gai.conf to prefer IPv4 addresses over IPv6
 	config.vm.provision "shell", inline: "echo \"precedence ::ffff:0:0/96  100\" > /etc/gai.conf"


### PR DESCRIPTION
Let's see all of the gory details of booting up.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/408)
<!-- Reviewable:end -->
