### PR TITLE
Changes needed to provision dev clusters

### DIFF
--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -47,7 +47,15 @@ set_defaults() {
     export SHORT_ARCHIVE_NAME="$(make -s -f $d/include/Makefile.version .short_archive_name)"
     export ARCHIVE_NAME="$SHORT_ARCHIVE_NAME-$IEEL_VERSION.tar.gz"
 
-    export PROVISIONER=${PROVISIONER:-"$HOME/provisionchroma -v -S --provisioner /home/bmurrell/provisioner"}
+    if $JENKINS; then
+        export PROVISIONER=${PROVISIONER:-"$HOME/provisionchroma -v -S --provisioner /home/bmurrell/provisioner"}
+    fi
+
+    if [ -n "$PROVISIONER" ]; then
+        export VAGRANT=false
+    else
+        export VAGRANT=true
+    fi
 
     if [ "$MEASURE_COVERAGE" != "true" -a "$MEASURE_COVERAGE" != "false" ]; then
         if $JENKINS; then

--- a/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
+++ b/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
@@ -13,7 +13,7 @@ CLUSTER_CONFIG=${CLUSTER_CONFIG:?"Need to specify a CLUSTER_CONFIG path to outpu
 
 if ! $JENKINS; then
     export BUILD_JOB_NAME="foo"
-    export BUILD_JOB_BUILD_NUMBER=1
+    export BUILD_JOB_BUILD_NUMBER=0
     cp $CLUSTER_CONFIG_TEMPLATE{,.tmp}
     CLUSTER_CONFIG_TEMPLATE="${CLUSTER_CONFIG_TEMPLATE}.tmp"
 fi
@@ -29,7 +29,7 @@ sed -i -e "s/BUILD_JOB_NAME/${BUILD_JOB_NAME}/g" \
 python $CHROMA_DIR/chroma-manager/tests/framework/utils/provisioner_interface/test_json2provisioner_json.py $CLUSTER_CONFIG_TEMPLATE provisioner_input.json || (echo "test_json2provisioner_json.py failed. Input: `cat $CLUSTER_CONFIG_TEMPLATE`" && exit 1)
 cat provisioner_input.json
 
-if $JENKINS; then
+if ! $VAGRANT; then
     # Actually call the provisioner. Once the command returns, provisioning is complete.
     rc=0
     PROVISION_START_TIME=$(date '+%s')


### PR DESCRIPTION
These changes allow one to run (say) SSI tests from your
local machine using your dev cluster as the place to run
the test.

An example commandline for running SSI tests for example:

$ make PROVISIONER="ssh <idsid>@ssi-builder.lotus.hpdd.lab.intel.com \\
OS=stdin sudo provision" ssi_tests

This should work equally well for efs_tests or upgrade_tests.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/411)
<!-- Reviewable:end -->
