### PR TITLE
Run SSI on GA with add'l storage server repos

### DIFF
--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
@@ -41,6 +41,10 @@ if [ -f ~/storage_server.repo ]; then
     STORAGE_SERVER_REPO=~/storage_server.repo
 fi
 
+if [ -n "$RELEASE_ARCHIVE" ]; then
+    ARCHIVE_NAME=${RELEASE_ARCHIVE##*/}
+fi
+
 # Install and setup manager
 scp $STORAGE_SERVER_REPO $ARCHIVE_PATH/$ARCHIVE_NAME $CHROMA_DIR/chroma-manager/tests/utils/install.exp root@$CHROMA_MANAGER:/tmp
 ssh root@$CHROMA_MANAGER "#don't do this, it hangs the ssh up, when used with expect, for some reason: exec 2>&1
@@ -100,6 +104,12 @@ if [ -f /etc/profile.d/intel_proxy.sh ]; then
     echo \". /etc/profile.d/intel_proxy.sh\" > /etc/sysconfig/chroma-agent
 fi
 
+# any repos required by this test run
+if [ -n \"$STORAGE_SERVER_REPOS\" ]; then
+    for repo in $STORAGE_SERVER_REPOS; do
+        yum-config-manager --add-repo \$repo
+    done
+fi
 # https://github.com/pypa/virtualenv/issues/355
 python_version=\$(python -c 'import platform; print \".\".join(platform.python_version_tuple()[0:2])')
 if $MEASURE_COVERAGE; then

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/jenkins_steps/main
@@ -12,8 +12,10 @@ if ! $JENKINS; then
 fi
 export CLUSTER_CONFIG_TEMPLATE=${CLUSTER_CONFIG_TEMPLATE:-"$CHROMA_DIR/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/shared_storage_configuration_cluster_cfg.json"}
 
-if $JENKINS; then
-    cd $WORKSPACE
+cd $WORKSPACE
+if [ -n "$RELEASE_ARCHIVE" ]; then
+    curl -L -f -O "https://github.com/intel-hpdd/intel-manager-for-lustre/releases/download/$RELEASE_ARCHIVE"
+elif $JENKINS; then
     curl -f -k -O "$JOB_URL/$ARCHIVE_NAME"
 fi
 


### PR DESCRIPTION
Changes to allow one to run an SSI test on a GA release of
IML with additional storage server repos.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/412)
<!-- Reviewable:end -->
