### PR TITLE
Read lightweight tags for release

### DIFF
--- a/include/Makefile.version
+++ b/include/Makefile.version
@@ -5,7 +5,7 @@ BUILD_TAG		?= non-jenkins-build
 JENKINS_BUILD_TAG	:= $(shell echo jenkins-$(JOB_NAME)-$(BUILD_NUMBER) | sed -e 's/arch=[^,-]*,\?-\?//' -e 's/distro=[^,-]*,\?-\?//' -e 's,[/-],_,g')
 SCM_DESCRIPTION		:= $(shell msg=$$(git log -n 1 --abbrev-commit); if echo "$$msg" | grep -q "^    Create-Tag:"; then echo "$$msg" | sed -ne '/^    Create-Tag:/s/RC[0-9]*//;s/^.*: *v//p';/^    Create-Tag:/s/P[0-9]*//; fi)
 ifeq ($(strip $(SCM_DESCRIPTION)),)
-SCM_DESCRIPTION		:= $(subst -,$(space),$(shell git describe --match v[0-9]* | sed -e 's/^v//' -e 's/RC[0-9]*//' -e 's/P[0-9]*//'))
+SCM_DESCRIPTION		:= $(subst -,$(space),$(shell git describe --tags --match v[0-9]* | sed -e 's/^v//' -e 's/RC[0-9]*//' -e 's/P[0-9]*//'))
 endif
 ARCHIVE_NAME		:= Intel Enterprise Edition for Lustre Software
 SHORT_ARCHIVE_NAME	:= iml


### PR DESCRIPTION
Our code for reading tags assumes an annotated tag.

This is sub-optimal for releasing software using Github.

A typical software release on Github follows this process:

1. Go to the releases tab on the project and create a release (this creates a lightweight tag in the process).
2. Your build system (Travis etc...) will pick up on the release, and build the software. It will then publish it to the relevant spot (registry etc...).

We currently do not follow this workflow. Our build script is expecting an annotated tag, which means we need to:

1. Tag locally.
2. Push the tag to origin
3. Create a release from that existing tag.
4. Trigger and mark a build by hand.
5. Upload the artifact back to the release page.

We should additionally add a job that follows what Typical cloud CI providers do, but for now just allowing lightweight tags means we can create the release on github which is better than what we have to do today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/413)
<!-- Reviewable:end -->
