### PR TITLE
Bump to Lustre 2.10.2

### DIFF
--- a/chroma-manager/storage_server.repo
+++ b/chroma-manager/storage_server.repo
@@ -11,13 +11,13 @@ enabled_metadata=1
 
 [lustre]
 name=Lustre Server
-baseurl=https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/server/
+baseurl=https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.2/el7/server/
 enabled=1
 gpgcheck=0
 
 [lustre-client]
 name=Lustre Client
-baseurl=https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/client/
+baseurl=https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.2/el7/client/
 enabled=1
 gpgcheck=0
 

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -117,11 +117,11 @@ set_defaults() {
         export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_server_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
         export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/build.whamcloud.com_lustre-reviews_configurations_axis-arch_\\\$basearch_axis-build_type_client_axis-distro_el7_axis-ib_stack_inkernel_builds_${LUSTRE_REVIEW_BUILD}_archive_artifacts_.repo"
     else
-        BASE_URL="https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.1/el7/"
+        BASE_URL="https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.2/el7/"
         export LUSTRE_SERVER_URL="$BASE_URL/server/"
         export LUSTRE_CLIENT_URL="$BASE_URL/client/"
         # these should be determined from the above
-        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_server_.repo"
-        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.1_el7_client_.repo"
+        export LUSTRE_SERVER_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.2_el7_server_.repo"
+        export LUSTRE_CLIENT_REPO_FILE="/etc/yum.repos.d/downloads.hpdd.intel.com_public_lustre_lustre-2.10.2_el7_client_.repo"
     fi
 } # end of set_defaults()


### PR DESCRIPTION
Now that 2.10.2 is out we should use it in IML.

Signed-off-by: Joe Grund <joe.grund@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/423)
<!-- Reviewable:end -->
