### PR TITLE
Sync normalized device table with paths

### DIFF
--- a/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
@@ -135,7 +135,7 @@ def fetch_device_list():
 
 
 def add_to_ndp(xs, ys):
-    for x in reversed(xs):
+    for x in xs:
         for y in reversed(ys):
             ndp.add_normalized_device(x, y)
 

--- a/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_components/block_devices.py
@@ -135,8 +135,8 @@ def fetch_device_list():
 
 
 def add_to_ndp(xs, ys):
-    for x in xs:
-        for y in ys:
+    for x in reversed(xs):
+        for y in reversed(ys):
             ndp.add_normalized_device(x, y)
 
 


### PR DESCRIPTION
We currently have two (at least) representations of
device paths.

Ideally, we should (and will) remove all duplicate
copies of data, but for now make sure we iterate adding
items to the normalized device path in reverse so
the end result is equivalent to the path chosen.

Signed-off-by: Joe Grund <joe.grund@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/424)
<!-- Reviewable:end -->
