### PR TITLE
Support RHEL 7.5

### DIFF
--- a/chroma-agent/Target
+++ b/chroma-agent/Target
@@ -54,7 +54,8 @@ END
 }
 
 dbg() {
-    echo "`date` RA $1" >> /var/log/chroma-agent.log
+    # shellcheck disable=SC2102
+    echo "$(date +[%d/%b/%Y:%H:%M:%S]) RA $1" >> /var/log/chroma-agent.log
 }
 
 Target_start() {
@@ -79,6 +80,7 @@ Target_start() {
         dbg "Couldn't start target $TARGET"
         return $OCF_ERR_GENERIC
     fi
+    dbg "Leaving Target_start() with success"
     return $OCF_SUCCESS
 }
 

--- a/chroma-agent/chroma_agent/lib/shell.py
+++ b/chroma-agent/chroma_agent/lib/shell.py
@@ -91,7 +91,7 @@ class AgentShell(BaseShell):
 
     @classmethod
     def run_old(cls, arg_list):
-        """ This method is provided for backwards compatibility only, use run_new() in new code """
+        """ This method is provided for backwards compatibility only, use run() in new code """
         result = AgentShell.run(arg_list)
 
         return result.rc, result.stdout, result.stderr

--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -72,7 +72,7 @@ def _check_platform():
     SUPPORTED_DISTROS = ['redhat', 'centos']
     # Keep the version locked down for now -- if we can go with a minimum
     # version that'd be better, but we can't assume (c.f. pacemaker).
-    SUPPORTED_VERSIONS = ['7.1', '7.1.1503', '7.2', '7.2.1511', '7.3', '7.3.1611', '7.4', '7.4.1708']
+    SUPPORTED_VERSIONS = ['7.1', '7.1.1503', '7.2', '7.2.1511', '7.3', '7.3.1611', '7.4', '7.4.1708', '7.5']
     # This will work assuming we have version parity across all supported
     # distributions.
     SUPPORTED_PLATFORMS = ["%s-%s-%s" % p for p in itertools.product(SUPPORTED_DISTROS, SUPPORTED_VERSIONS, SUPPORTED_ARCHES)]

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -117,7 +117,8 @@ fi
 
 # Install a client
 source $CHROMA_DIR/chroma-manager/tests/framework/integration/utils/install_client.sh
-wait_for_nodes "$CLIENT_1" "[ \$(uname -r) = \$(grubby --default-kernel | sed -e 's/.*z-//') ]"
+wait_for_nodes "$CLIENT_1" "rpm -q kmod-lustre-client || exit 0
+[ \$(uname -r) = \$(grubby --default-kernel | sed -e 's/.*z-//') ]"
 
 echo "Create and exercise a filesystem..."
 

--- a/chroma-manager/tests/framework/integration/utils/install_client.sh
+++ b/chroma-manager/tests/framework/integration/utils/install_client.sh
@@ -2,6 +2,9 @@
 
 # Install the Lustre client
 
+# shellcheck disable=SC1090
+. "$CHROMA_DIR"/chroma-manager/tests/framework/integration/utils/reboot_node.sh
+
 # shellcheck disable=SC2029
 ssh root@"$CLIENT_1" "exec 2>&1; set -xe
 # set up required repos

--- a/chroma-manager/tests/framework/integration/utils/node_lib.sh
+++ b/chroma-manager/tests/framework/integration/utils/node_lib.sh
@@ -2,11 +2,8 @@
 
 # Functions to deal with nodes
 
-# shellcheck disable=SC2034
-# REBOOT_NODE is used by other scripts that include this one
-REBOOT_NODE="sync
-sync
-nohup bash -c \"sleep 2; init 6\" >/dev/null 2>/dev/null </dev/null & exit 0"
+# shellcheck disable=SC1091
+. $CHROMA_DIR/chroma-manager/tests/framework/integration/utils/reboot_node.sh
 
 reset_node() {
     local node="$1"

--- a/chroma-manager/tests/framework/integration/utils/reboot_node.sh
+++ b/chroma-manager/tests/framework/integration/utils/reboot_node.sh
@@ -1,0 +1,5 @@
+# REBOOT_NODE is used by other scripts that include this one
+# shellcheck disable=SC2034
+export REBOOT_NODE="sync
+sync
+nohup bash -c \"sleep 2; init 6\" >/dev/null 2>/dev/null </dev/null & exit 0"

--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -17,9 +17,9 @@ set_distro_vars() {
     if [ "$distro" = "el7" ]; then
         if ${upgrade_test}; then
             export TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-"7.3"}
-            export UPGRADE_DISTRO_VERSION=${UPGRADE_DISTRO_VERSION:-"7.4"}
+            export UPGRADE_DISTRO_VERSION=${UPGRADE_DISTRO_VERSION:-"7.5"}
         else
-            export TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-"7.4"}
+            export TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-"7.5"}
         fi
     else
        if ${upgrade_test}; then

--- a/chroma-manager/tests/framework/utils/selective_auto_pass.sh
+++ b/chroma-manager/tests/framework/utils/selective_auto_pass.sh
@@ -64,4 +64,12 @@ check_for_autopass() {
       fake_test_pass "tests_skipped_because_unsupported_distro_$TEST_DISTRO_VERSION" "$WORKSPACE/test_reports/" "$BUILD_NUMBER"
       exit 0
     fi
+
+    # RHEL 7.5 won't upgrade CentOS 7.3
+    if [[ ($JOB_NAME == upgrade-tests || $JOB_NAME == upgrade-tests/*) &&
+        $TEST_DISTRO_NAME != rhel ]]; then
+        fake_test_pass "upgrade-tests_skipped_on_centos7.3" "$WORKSPACE/test_reports/" "${BUILD_NUMBER}"
+        exit 0
+    fi
+
 }  # end of check_for_autopass()

--- a/chroma-manager/tests/services/test_nginx.py
+++ b/chroma-manager/tests/services/test_nginx.py
@@ -227,9 +227,14 @@ class TestCrypto(SupervisorTestCase):
                           ssl_version=ssl.PROTOCOL_SSLv3)
 
     def test_ssl2_disabled(self):
-        self.assertRaises(socket.error,
-                          self._connect_socket,
-                          ssl_version=ssl.PROTOCOL_SSLv2)
+        try:
+            self.assertRaises(socket.error,
+                              self._connect_socket,
+                              ssl_version=ssl.PROTOCOL_SSLv2)
+        except AttributeError:
+            # RHEL 7.5 (for example)'s Python doesn't support
+            # SSLv2 any more
+            pass
 
     def test_tls1_disabled(self):
         self.assertRaises(socket.error,


### PR DESCRIPTION
Fixes #485

IML 3.1 only supports up to EL 7.3 so start upgrade testing
from RHEL 7.3, not 7.4.

RHEL 7.5's Python doesn't support SSLv2 so allow attribute
exception in any SSLv2 tests.

Auto-pass upgrade testing on CentOS because RHEL 7.5 won't
upgrade CentOS 7.3 due to distro packaging incompatibilities.

Slight change in crm_mon where it now reports on resources while
they are starting so only report locations of Started resources
and not Starting resources.  Additionally, a target that is
"Stopping" has not completed the transistion from "Started" (i.e.
running) to Stopped, so count it as running until it completes
the transition.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/426)
<!-- Reviewable:end -->
