### PR TITLE
Update manager and agent dependencies for reactive architecture

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -32,7 +32,7 @@ Requires: python2-iml-common1.3
 Requires: systemd-python
 Requires: python-tzlocal
 Requires: python2-toolz
-Requires: iml-device-scanner
+Requires: iml-scanner-proxy
 %if 0%{?rhel} > 5
 Requires: util-linux-ng
 %endif

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -58,6 +58,7 @@ Requires: iml-supervisor-status
 Requires: iml-gui
 Requires: iml-srcmap-reverse
 Requires: iml-online-help
+Requires: iml-device-aggregator
 Requires: createrepo
 Requires: python2-toolz
 Conflicts: chroma-agent

--- a/chroma-manager/chroma_core/plugins/block_devices.py
+++ b/chroma-manager/chroma_core/plugins/block_devices.py
@@ -19,7 +19,7 @@ from chroma_core.services import log_register
 log = log_register('plugin_runner')
 log.setLevel(DEBUG)
 
-UNSUPPORTED_STATES = ['EXPORTED', 'UNAVAIL']
+UNAVAILABLE_STATES = ['EXPORTED', 'UNAVAIL']
 
 DeviceMaps = namedtuple('device_maps', 'block_devices zpools zfs props')
 
@@ -369,7 +369,7 @@ def parse_zpools(zpool_map, zfs_objs, block_device_nodes):
     datasets = {}
     # fixme: get zvols from zfs_objs using some identifier to discern from datasets
 
-    for pool in zpool_map.values():
+    def populate(pool):
         name = pool['name']
         guid = pool['guid']
 
@@ -439,6 +439,10 @@ def parse_zpools(zpool_map, zfs_objs, block_device_nodes):
 
         block_device_nodes.update(_devs)
 
+    map(populate,
+        filter(lambda x: x['state'] not in UNAVAILABLE_STATES,
+               zpool_map.itervalues()))
+
     return [zpools, datasets, block_device_nodes]
 
 
@@ -476,7 +480,7 @@ def discover_zpools(all_devs):
 
         # verify pool is imported
         pools = pipe(maps['zed']['zpools'].itervalues(),
-                     cfilter(lambda pool: pool['state'] not in UNSUPPORTED_STATES),
+                     cfilter(lambda pool: pool['state'] not in UNAVAILABLE_STATES),
                      cfilter(match_drives),
                      list)
 
@@ -501,7 +505,7 @@ def discover_zpools(all_devs):
     # verify we haven't already got a representation for this pool locally
     if any(guid for guid in all_devs['zfspools'].iterkeys()
            if guid in other_zpools_zfs['zpools'].keys()
-            and other_zpools_zfs['zpools'][guid]['state'] not in UNSUPPORTED_STATES):
+            and other_zpools_zfs['zpools'][guid]['state'] not in UNAVAILABLE_STATES):
         raise RuntimeError("duplicate active representations of zpool (local)")
 
     # updates reported devices


### PR DESCRIPTION
Update manager to require `iml-device-aggregator` and agent to require `iml-scanner-proxy` (which itself requires `iml-device-scanner2`).

requirements include
* availability of relevant packages via relevant repositories (currently temporarily sourced from bintray)
* landing of https://github.com/intel-hpdd/scanner-proxy/pull/7

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/464)
<!-- Reviewable:end -->
