### PR TITLE
Mark exported pools as not usable so they don't appear in volumes page

### DIFF
--- a/chroma-manager/chroma_core/plugins/block_devices.py
+++ b/chroma-manager/chroma_core/plugins/block_devices.py
@@ -19,7 +19,7 @@ from chroma_core.services import log_register
 log = log_register('plugin_runner')
 log.setLevel(DEBUG)
 
-UNSUPPORTED_STATES = ['EXPORTED', 'UNAVAIL']
+UNAVAILABLE_STATES = ['EXPORTED', 'UNAVAIL']
 
 DeviceMaps = namedtuple('device_maps', 'block_devices zpools zfs props')
 
@@ -369,7 +369,7 @@ def parse_zpools(zpool_map, zfs_objs, block_device_nodes):
     datasets = {}
     # fixme: get zvols from zfs_objs using some identifier to discern from datasets
 
-    for pool in zpool_map.values():
+    def populate(pool):
         name = pool['name']
         guid = pool['guid']
 
@@ -439,6 +439,10 @@ def parse_zpools(zpool_map, zfs_objs, block_device_nodes):
 
         block_device_nodes.update(_devs)
 
+    map(populate,
+        filter(lambda x: x['state'] not in UNAVAILABLE_STATES,
+               zpool_map.itervalues()))
+
     return [zpools, datasets, block_device_nodes]
 
 
@@ -476,7 +480,7 @@ def discover_zpools(all_devs):
 
         # verify pool is imported
         pools = pipe(maps['zed']['zpools'].itervalues(),
-                     cfilter(lambda pool: pool['state'] not in UNSUPPORTED_STATES),
+                     cfilter(lambda pool: pool['state'] not in UNAVAILABLE_STATES),
                      cfilter(match_drives),
                      list)
 
@@ -501,7 +505,7 @@ def discover_zpools(all_devs):
     # verify we haven't already got a representation for this pool locally
     if any(guid for guid in all_devs['zfspools'].iterkeys()
            if guid in other_zpools_zfs['zpools'].keys()
-            and other_zpools_zfs['zpools'][guid]['state'] not in UNSUPPORTED_STATES):
+            and other_zpools_zfs['zpools'][guid]['state'] not in UNAVAILABLE_STATES):
         raise RuntimeError("duplicate active representations of zpool (local)")
 
     # updates reported devices


### PR DESCRIPTION
Currently exported pools are reported in `device-aggregator` output. Given the manager should not be reporting exported zpools as suitable volumes we want to detect exported state and not report.

Although if a zpool is available on a secondary host (but still inactive/exported) we do want to be able to list it as a secondary mount. Therefore in this case it could be reported as ACTIVE whilst imported on the primary.

Another situation may arise where a zpool is not imported on any hosts but the constituent drives are visible, in this case we don't want to be displaying the underlying disk partitions used in a zpool as usable volumes. In this case the primary partition can be identified as *FS_TYPE=zfs_member* and the disk identifier as well as partitions 1 & 9 can be marked as not usable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/469)
<!-- Reviewable:end -->
