### PR TITLE
Prevent chroma-agent.service from starting after restarting agents.

### DIFF
--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -194,12 +194,6 @@ class CreateLustreFilesystem(UtilityTestCase):
 
         self._save_modified_config()
 
-        for server in config['lustre_servers']:
-            self.remote_command(
-                server['address'],
-                'systemctl enable chroma-agent.service && systemctl start chroma-agent.service'
-            )
-
     def get_targets_by_kind(self, kind):
         return [v for k, v in config['filesystem']['targets'].iteritems() if v['kind'] == kind]
 


### PR DESCRIPTION
Fixes GH-477.

- Prevents chroma-agent.service from automatically starting when
  restarting the agent nodes in create_lustre_filesystem integration
  test.
- enable chroma-agent.service and start the service after the filesystem
  is created.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/478)
<!-- Reviewable:end -->
