### PR TITLE
Pools need to be exported if target mount fails

### DIFF
--- a/chroma-agent/chroma_agent/action_plugins/manage_targets.py
+++ b/chroma-agent/chroma_agent/action_plugins/manage_targets.py
@@ -448,7 +448,13 @@ def mount_target(uuid, pacemaker_ha_operation):
 
     filesystem = FileSystem(info['backfstype'], info['bdev'])
 
-    filesystem.mount(info['mntpt'])
+    try:
+        filesystem.mount(info['mntpt'])
+    except RuntimeError, e:
+        # Make sure we export any pools when a mount fails
+        export_target(info['device_type'], info['bdev'])
+
+        raise e
 
 
 def unmount_target(uuid):


### PR DESCRIPTION
Fixes #476

In:

https://github.com/intel-hpdd/intel-manager-for-lustre/blob/5312a68772791aefa940f1774ff878df163f7d2d/chroma-agent/chroma_agent/action_plugins/manage_targets.py#L428-L451

we do not export the device(zpool) if it imports and the subsequent target mount fails.

The simplest approach (since the pools are managed by IML), is to export the pool if the target mount fails.

Signed-off-by: Joe Grund <joe.grund@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/479)
<!-- Reviewable:end -->
