### PR TITLE
Environment: pragma in commit message

### DIFF
--- a/chroma-manager/tests/framework/utils/selective_auto_pass.sh
+++ b/chroma-manager/tests/framework/utils/selective_auto_pass.sh
@@ -2,7 +2,9 @@
 
 # At present bumps to the GUI only are auto passed.
 
+# shellcheck disable=SC1091
 . chroma-manager/tests/framework/utils/gui_update.sh
+# shellcheck disable=SC1091
 . chroma-manager/tests/framework/utils/fake_pass.sh
 
 check_for_autopass() {
@@ -14,41 +16,52 @@ check_for_autopass() {
     # upgrade-tests
     # unit-tests
     # vvvvvvvvvvv this should come from a pragma in the commit message
-    ALL_TESTS="integration-tests-existing-filesystem-configuration
-               integration-tests-shared-storage-configuration
-               integration-tests-shared-storage-configuration-with-simulator
-               test-services
-               unit-tests
-               upgrade-tests"
+    local all_tests="integration-tests-existing-filesystem-configuration
+                     integration-tests-shared-storage-configuration
+                     integration-tests-shared-storage-configuration-with-simulator
+                     test-services
+                     unit-tests
+                     upgrade-tests"
+    local commit_message tests_to_run
     commit_message=$(git log -n 1)
-    TESTS_TO_RUN=$(echo "$commit_message" | sed -ne '/^ *Run-tests:/s/^ *Run-tests: *//p')
-    if [ -n "$TESTS_TO_RUN" ]; then
-        TESTS_TO_SKIP=$ALL_TESTS
-        for t in $TESTS_TO_RUN; do
-            TESTS_TO_SKIP=${TESTS_TO_SKIP/$t/}
+    tests_to_run=$(echo "$commit_message" | sed -ne '/^ *Run-tests:/s/^ *Run-tests: *//p')
+    if [ -n "$tests_to_run" ]; then
+        tests_to_skip=$all_tests
+        for t in $tests_to_run; do
+            tests_to_skip=${tests_to_skip/$t/}
         done
     else
-        TESTS_TO_SKIP=$(echo "$commit_message" | sed -ne '/^ *Skip-tests:/s/^ *Skip-tests: *//p')
+        tests_to_skip=$(echo "$commit_message" | sed -ne '/^ *Skip-tests:/s/^ *Skip-tests: *//p')
     fi
-    for t in $TESTS_TO_SKIP; do
-        if [[ $JOB_NAME == $t || $JOB_NAME == $t/* ]]; then
+    # set any environment the test run wants
+    local environment
+    environment=$(echo "$commit_message" | sed -ne '/^ *Environment:/s/^ *Environment: *//p')
+    if [ -n "$environment" ]; then
+        # shellcheck disable=SC2163
+        # shellcheck disable=SC2086
+        export ${environment?}
+    fi
+
+    local t
+    for t in $tests_to_skip; do
+        if [[ $JOB_NAME == "$t" || $JOB_NAME == "$t/*" ]]; then
             echo "skipping this test due to {Run|Skip}-tests pragma"
-            fake_test_pass "tests_skipped_because_commit_pragma" "$WORKSPACE/test_reports/" ${BUILD_NUMBER}
+            fake_test_pass "tests_skipped_because_commit_pragma" "$WORKSPACE/test_reports/" "$BUILD_NUMBER"
             exit 1
         fi
     done
 
     tests_required_for_gui_bumps="chroma-tests-services"
 
-    if [[ $BUILD_JOB_NAME = *-reviews ]] && gui_bump && [[ ! $tests_required_for_gui_bumps = $JOB_NAME ]]; then
-      fake_test_pass "tests_skipped_because_gui_version_bump" "$WORKSPACE/test_reports/" ${BUILD_NUMBER}
+    if [[ $BUILD_JOB_NAME = "*-reviews" ]] && gui_bump && [[ ! $tests_required_for_gui_bumps = "$JOB_NAME" ]]; then
+      fake_test_pass "tests_skipped_because_gui_version_bump" "$WORKSPACE/test_reports/" "$BUILD_NUMBER"
       exit 0
     fi
 
     # regex matches separated by |
     supported_distro_versions="7\.[0-9]+"
     if [[ ! $TEST_DISTRO_VERSION =~ $supported_distro_versions ]] && ([ -z "$UPGRADE_TEST_DISTRO" ] || [[ ! $UPGRADE_TEST_DISTRO =~ $supported_distro_versions ]]); then
-      fake_test_pass "tests_skipped_because_unsupported_distro_$TEST_DISTRO_VERSION" "$WORKSPACE/test_reports/" ${BUILD_NUMBER}
+      fake_test_pass "tests_skipped_because_unsupported_distro_$TEST_DISTRO_VERSION" "$WORKSPACE/test_reports/" "$BUILD_NUMBER"
       exit 0
     fi
 }  # end of check_for_autopass()


### PR DESCRIPTION
Allow one to set test environment values with an Environment:
pragma in the commit message.

Used by adding a line to the commit message that starts with
the word Environment: followed by environment variables to set
such as "NOSE_ARGS=-x TESTS=tests/integration/shared_storage_configuration/test_conf_params.py:TestConfParams.test_writeconf_conf_params"
(without the quotes) as an example.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/487)
<!-- Reviewable:end -->
