### PR TITLE
Unpin device-scanner

### DIFF
--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -32,7 +32,7 @@ Requires: python2-iml-common1.3
 Requires: systemd-python
 Requires: python-tzlocal
 Requires: python2-toolz
-Requires: iml-device-scanner < 2.0.0
+Requires: iml-device-scanner
 %if 0%{?rhel} > 5
 Requires: util-linux-ng
 %endif


### PR DESCRIPTION
Now that device-scanner is going to be
backwards compatible, unpin it.

Signed-off-by: Joe Grund <joe.grund@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/490)
<!-- Reviewable:end -->
