### PR TITLE
Revert O/S version back to EL 7.4 for compat test

### DIFF
--- a/chroma-manager/tests/framework/utils/defaults.sh
+++ b/chroma-manager/tests/framework/utils/defaults.sh
@@ -17,9 +17,9 @@ set_distro_vars() {
     if [ "$distro" = "el7" ]; then
         if ${upgrade_test}; then
             export TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-"7.3"}
-            export UPGRADE_DISTRO_VERSION=${UPGRADE_DISTRO_VERSION:-"7.5"}
+            export UPGRADE_DISTRO_VERSION=${UPGRADE_DISTRO_VERSION:-"7.4"}
         else
-            export TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-"7.5"}
+            export TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-"7.4"}
         fi
     else
        if ${upgrade_test}; then

--- a/chroma-manager/tests/framework/utils/selective_auto_pass.sh
+++ b/chroma-manager/tests/framework/utils/selective_auto_pass.sh
@@ -64,12 +64,4 @@ check_for_autopass() {
       fake_test_pass "tests_skipped_because_unsupported_distro_$TEST_DISTRO_VERSION" "$WORKSPACE/test_reports/" "$BUILD_NUMBER"
       exit 0
     fi
-
-    # RHEL 7.5 won't upgrade CentOS 7.3
-    if [[ ($JOB_NAME == upgrade-tests || $JOB_NAME == upgrade-tests/*) &&
-        $TEST_DISTRO_NAME != rhel ]]; then
-        fake_test_pass "upgrade-tests_skipped_on_centos7.3" "$WORKSPACE/test_reports/" "${BUILD_NUMBER}"
-        exit 0
-    fi
-
 }  # end of check_for_autopass()


### PR DESCRIPTION
To ensure the changes needed for RHEL 7.5 don't break EL 7.4, do
a test run reverting the test O/S back to EL 7.4.

DO NOT LAND!  FOR VERIFICATION PURPOSES ONLY.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/510)
<!-- Reviewable:end -->
