### PR TITLE
GH-504 Starting agent pushes journal entry without facility

### DIFF
--- a/chroma-agent/chroma_agent/device_plugins/systemd_journal.py
+++ b/chroma-agent/chroma_agent/device_plugins/systemd_journal.py
@@ -36,8 +36,8 @@ def parse_journal(data):
     return {
         'datetime': datetime.datetime.isoformat(utc_dt),
         'severity': data['PRIORITY'],
-        'facility': data['SYSLOG_FACILITY'],
-        'source': data.get('SYSLOG_IDENTIFIER', "unknown"),
+        'facility': data.get('SYSLOG_FACILITY', 'unknown'),
+        'source': data.get('SYSLOG_IDENTIFIER', 'unknown'),
         'message': data['MESSAGE']
     }
 

--- a/chroma-agent/chroma_agent/device_plugins/systemd_journal.py
+++ b/chroma-agent/chroma_agent/device_plugins/systemd_journal.py
@@ -36,7 +36,7 @@ def parse_journal(data):
     return {
         'datetime': datetime.datetime.isoformat(utc_dt),
         'severity': data['PRIORITY'],
-        'facility': data.get('SYSLOG_FACILITY', 'unknown'),
+        'facility': data.get('SYSLOG_FACILITY', 3),
         'source': data.get('SYSLOG_IDENTIFIER', 'unknown'),
         'message': data['MESSAGE']
     }


### PR DESCRIPTION
starting the agent produces a journal entry like:

```json
{
     "source": "dracut",
      "message": "-rwxr-xr-x   1 root     root          422 Aug  5  2017
      usr/bin/dracut-cmdline-ask",
       "severity": 7,
        "datetime": "2018-03-16T23:48:25.848126+00:00"
}
```

This breaks our current systemd_journal handling, as we expect
everything to have a SYSLOG_FACILITY

Fixes #504.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/518)
<!-- Reviewable:end -->
