### PR TITLE
Always replace the chroma_support.repo during install

### DIFF
--- a/chroma-bundles/install
+++ b/chroma-bundles/install
@@ -330,13 +330,12 @@ def _create_support_repos():
     repodir = "/etc/yum.repos.d"
     repofile = "chroma_support.repo"
     target_path = os.path.join(repodir, repofile)
-    if not os.path.exists(target_path):
-        try:
-            shutil.copy(repofile, repodir)
-        except:
-            log.debug("Failed to create %s." % target_path)
-            log.info("Failed to create %s." % target_path)
-            sys.exit(-1)
+    try:
+        shutil.copy(repofile, repodir)
+    except:
+        log.debug("Failed to create %s." % target_path)
+        log.info("Failed to create %s." % target_path)
+        sys.exit(-1)
 
 def _create_manager_repo():
     manager_repo_dir = tempfile.mkdtemp()


### PR DESCRIPTION
We need to always be able to change the repos used for an
IML installation on every upgrade.

Users who want to override any of those repos need to do
so in the copy that is in the install dir *before* they
do an installation/upgrade.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-hpdd/intel-manager-for-lustre/523)
<!-- Reviewable:end -->
