### PR TITLE
Fixup zfs parsing in manager block_devices

### DIFF
--- a/chroma-manager/chroma_core/plugins/block_devices.py
+++ b/chroma-manager/chroma_core/plugins/block_devices.py
@@ -390,7 +390,7 @@ def parse_zpools(zed, block_device_nodes):
                 "size": 0,  # fixme
                 "drives": drive_mms
             }
-            for ds in [d for d in pool.datasets]
+            for ds in [d for d in pool['datasets']]
         }
 
         _devs = {}

--- a/chroma-manager/chroma_core/plugins/block_devices.py
+++ b/chroma-manager/chroma_core/plugins/block_devices.py
@@ -490,18 +490,17 @@ def discover_zpools(all_devs, _data):
 
         pools = {pool['guid']: pool for pool in pools}
 
-        # verify we haven't already got a representation for this pool on any of the other hosts
+        # verify we haven't already got a representation for this pool on any other hosts
         if any(guid for guid in pools.keys() if guid in acc['zpools'].keys()):
             raise RuntimeError("duplicate active representations of zpool (remote)")
 
         acc['zpools'].update(pools)
 
-        acc['zfs'].extend([d for d in maps['zed']['zfs']
-                           if int(d['poolGuid'], 16) in [int(h, 16) for h in pools.keys()]])
-
         return acc
 
-    other_zpools_zfs = reduce(extract, filter(None, _data.values()), {'zpools': {}, 'zfs': []})
+    other_zpools_zfs = reduce(extract, filter(None, _data.values()), {
+        'zpools': {}
+    })
 
     # verify we haven't already got a representation for this pool locally
     if any(guid for guid in all_devs['zfspools'].iterkeys()


### PR DESCRIPTION
Fixup zfs parsing in manager block_devices to work with new device-scanner.

TODO:
* process vdev tree not just the root node in https://github.com/intel-hpdd/intel-manager-for-lustre/pull/456 when enumerating zpool disks in https://github.com/intel-hpdd/intel-manager-for-lustre/pull/456/files#diff-9b785746172b9590b8d0bc97151ee6edR377