### PR TITLE
Easily set other module Jenkins builds...

### DIFF
--- a/chroma-manager/tests/framework/utils/selective_auto_pass.sh
+++ b/chroma-manager/tests/framework/utils/selective_auto_pass.sh
@@ -31,6 +31,7 @@ check_for_autopass() {
     else
         tests_to_skip=$(echo "$commit_message" | sed -ne '/^ *Skip-tests:/s/^ *Skip-tests: *//p')
     fi
+
     # set any environment the test run wants
     local environment
     environment=$(echo "$commit_message" | sed -ne '/^ *Environment:/s/^ *Environment: *//p')
@@ -38,6 +39,12 @@ check_for_autopass() {
         # shellcheck disable=SC2163
         # shellcheck disable=SC2086
         export ${environment?}
+    fi
+
+    # use specified module builds
+    jenkins_modules=$(echo "$commit_message" | sed -ne '/^ *Module: *jenkins\//s/^ *Module: *jenkins\/\([^:]*\): *\([0-9][0-9]*\)/http:\/\/jenkins.lotus.hpdd.lab.intel.com\/job\/\1\/\2\/arch=x86_64,distro=el7\/artifact\/artifacts\/\1-test.repo/gp')
+    if [ -n "$jenkins_modules" ]; then
+        export STORAGE_SERVER_REPOS="$jenkins_modules $STORAGE_SERVER_REPOS"
     fi
 
     local t


### PR DESCRIPTION
to test with.

By setting a pragma in the commit message of the format
"Module: mod-name: number" the tests will be run with the
Jenkins build number "num" of the job "mod-name".

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>