### PR TITLE
Don't unmount workers in unmount_clients()

### DIFF
--- a/chroma-manager/tests/integration/core/remote_operations.py
+++ b/chroma-manager/tests/integration/core/remote_operations.py
@@ -745,7 +745,7 @@ class RealRemoteOperations(RemoteOperations):
         """
         Unmount all filesystems of type lustre from all clients in the config.
         """
-        for client in config['lustre_clients'] + self.config_workers:
+        for client in config['lustre_clients']:
             self._ssh_address(client['address'],
                               'umount -t lustre -a')
             self._ssh_address(client['address'],


### PR DESCRIPTION
Workers are an IML managed resource and should be manipulated
using IML, not outside of it.

Fixes: #548

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>