### PR TITLE
Disable the local-toolkit before testing

### DIFF
--- a/chroma-manager/tests/framework/utils/cluster_setup.sh
+++ b/chroma-manager/tests/framework/utils/cluster_setup.sh
@@ -19,6 +19,10 @@ echo "Beginning installation and setup..."
 # and make sure EPEL is enabled
 pdsh -l root -R ssh -S -w $(spacelist_to_commalist $ALL_NODES) "exec 2>&1; set -xe
 $LOCAL_CLUSTER_SETUP
+
+# disable the toolkit repo
+yum-config-manager --disable local-toolkit_el7-x86_64
+
 cat <<\"EOF\" >> /root/.ssh/authorized_keys
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrcI6x6Fv2nzJwXP5mtItOcIDVsiD0Y//LgzclhRPOT9PQ/jwhQJgrggPhYr5uIMgJ7szKTLDCNtPIXiBEkFiCf9jtGP9I6wat83r8g7tRCk7NVcMm0e0lWbidqpdqKdur9cTGSOSRMp7x4z8XB8tqs0lk3hWefQROkpojzSZE7fo/IT3WFQteMOj2yxiVZYFKJ5DvvjdN8M2Iw8UrFBUJuXv5CQ3xV66ZvIcYkth3keFk5ZjfsnDLS3N1lh1Noj8XbZFdSRC++nbWl1HfNitMRm/EBkRGVP3miWgVNfgyyaT9lzHbR8XA7td/fdE5XrTpc7Mu38PE7uuXyLcR4F7l brian@brian-laptop
 EOF


### PR DESCRIPTION
We really shouldn't need anything out of there once image
creation is complete, so remove it before starting testing.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>