### PR TITLE
Allow caller to override provisioned chroma repo

### DIFF
--- a/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
+++ b/chroma-manager/tests/framework/utils/provisioner_interface/provision_cluster
@@ -18,8 +18,8 @@ if ! $JENKINS; then
     CLUSTER_CONFIG_TEMPLATE="${CLUSTER_CONFIG_TEMPLATE}.tmp"
 fi
 # Fill in the Jenkins Build Job and Build Number, the IEEL version under test, and what OS to test it on.
-sed -i -e "s/BUILD_JOB_NAME/${BUILD_JOB_NAME}/g" \
-       -e "s/BUILD_JOB_BUILD_NUMBER/${BUILD_JOB_BUILD_NUMBER}/g" \
+sed -i -e "s/BUILD_JOB_NAME/${OVERRIDE_BUILD_JOB_NAME:-$BUILD_JOB_NAME}/g" \
+       -e "s/BUILD_JOB_BUILD_NUMBER/${OVERRIDE_BUILD_JOB_BUILD_NUMBER:-$BUILD_JOB_BUILD_NUMBER}/g" \
        -e "s/IEEL_VERSION/${IEEL_VERSION}/g" \
        -e "s/TEST_DISTRO_NAME/${TEST_DISTRO_NAME}/g" \
        -e "s/TEST_DISTRO_VERSION/${TEST_DISTRO_VERSION}/g" \

--- a/chroma-manager/tests/framework/utils/provisioner_interface/test_json2provisioner_json.py
+++ b/chroma-manager/tests/framework/utils/provisioner_interface/test_json2provisioner_json.py
@@ -12,10 +12,12 @@ test_json_file = open(sys.argv[1])
 config = json.load(test_json_file)
 test_json_file.close()
 
-# insert the jenkins metadata
+# insert the jenkins metadata if not done by the caller already
 if config.get('repos', False):
-    config['repos']['chroma']['build_job'] = os.environ['BUILD_JOB_NAME']
-    config['repos']['chroma']['build_number'] = int(os.environ['BUILD_JOB_BUILD_NUMBER'])
+    if config['repos']['chroma']['build_job'] == "BUILD_JOB_NAME":
+        config['repos']['chroma']['build_job'] = os.environ['BUILD_JOB_NAME']
+    if config['repos']['chroma']['build_number'] == "BUILD_JOB_BUILD_NUMBER":
+        config['repos']['chroma']['build_number'] = int(os.environ['BUILD_JOB_BUILD_NUMBER'])
 
 provisioner_json_file = open(sys.argv[2], 'w')
 json.dump(config, provisioner_json_file, sort_keys=True, indent=4)


### PR DESCRIPTION
Caller can set $OVERRIDE_BUILD_JOB_NAME and
$OVERRIDE_BUILD_JOB_BUILD_NUMBER to override the chroma repo
that is supplied by the provisioner.

Fix a related bug so that we only modify test config's
"repos" once.
- if the caller has already set them, don't [re-]set them in
  test_json2provisioner_json.py.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>