### PR TITLE
Create service grouping systemd units

### DIFF
--- a/chroma-agent/10-device-scanner.socket.conf
+++ b/chroma-agent/10-device-scanner.socket.conf
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=iml-storage-server.target

--- a/chroma-agent/10-device-scanner.target.conf
+++ b/chroma-agent/10-device-scanner.target.conf
@@ -1,0 +1,3 @@
+[Unit]
+PartOf=iml-storage-server.target
+Before=iml-storage-server.target

--- a/chroma-agent/Makefile
+++ b/chroma-agent/Makefile
@@ -38,7 +38,7 @@ rpms: production cleandist tarball
 	rm -rf _topdir
 	mkdir -p _topdir/{BUILD,S{PEC,OURCE,RPM}S,RPMS/noarch}
 	cp dist/chroma-agent-*.tar.gz _topdir/SOURCES
-	cp chroma-agent.service lustre-modules-init.sh logrotate.cfg \
+	cp chroma-agent.service lustre-modules-init.sh logrotate.cfg iml-storage-server.target 10-device-scanner.target.conf 10-device-scanner.socket.conf \
 	   _topdir/SOURCES
 	cp chroma-agent.spec _topdir/SPECS
 	dist=$$(rpm --eval %dist);                             \

--- a/chroma-agent/chroma-agent.service
+++ b/chroma-agent/chroma-agent.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=IML Agent Daemon
 After=network.target
-
-[Install]
-WantedBy=multi-user.target
+After=device-scanner.socket
+Requires=device-scanner.socket
+PartOf=iml-storage-server.target
 
 [Service]
 Type=simple
@@ -11,3 +11,7 @@ ExecStart=/usr/bin/chroma-agent-daemon
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=iml-storage-server.target

--- a/chroma-agent/chroma-agent.spec
+++ b/chroma-agent/chroma-agent.spec
@@ -11,6 +11,9 @@ Source0: %{name}-%{version}.tar.gz
 Source1: %{name}.service
 Source2: lustre-modules-init.sh
 Source3: logrotate.cfg
+Source4: iml-storage-server.target
+Source5: 10-device-scanner.target.conf
+Source6: 10-device-scanner.socket.conf
 License: Proprietary
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
@@ -100,6 +103,11 @@ cp %{SOURCE1} %{buildroot}/usr/lib/systemd/system/%{name}.service
 mkdir -p $RPM_BUILD_ROOT/etc/{init,logrotate}.d/
 cp %{SOURCE2} $RPM_BUILD_ROOT/etc/init.d/lustre-modules
 install -m 644 %{SOURCE3} $RPM_BUILD_ROOT/etc/logrotate.d/chroma-agent
+cp %{SOURCE4} %{buildroot}/usr/lib/systemd/system/iml-storage-server.target
+mkdir -p %{buildroot}/etc/systemd/system/device-scanner.target.d/
+cp %{SOURCE5} %{buildroot}/etc/systemd/system/device-scanner.target.d/10-device-scanner.target.conf
+mkdir -p %{buildroot}/etc/systemd/system/device-scanner.socket.d/
+cp %{SOURCE6} %{buildroot}/etc/systemd/system/device-scanner.socket.d/10-device-scanner.socket.conf
 
 touch management.files
 cat <<EndOfList>>management.files
@@ -157,6 +165,9 @@ grubby --set-default=/boot/vmlinuz-$MOST_RECENT_KERNEL_VERSION
 %files -f base.files
 %defattr(-,root,root)
 %attr(0644,root,root)/usr/lib/systemd/system/%{name}.service
+%attr(0644,root,root)/usr/lib/systemd/system/iml-storage-server.target
+%attr(0644,root,root)/etc/systemd/system/device-scanner.target.d/10-device-scanner.target.conf
+%attr(0644,root,root)/etc/systemd/system/device-scanner.socket.d/10-device-scanner.socket.conf
 %attr(0755,root,root)/etc/init.d/lustre-modules
 %{_bindir}/chroma-agent*
 %{python_sitelib}/chroma_agent-*.egg-info/*

--- a/chroma-agent/iml-storage-server.target
+++ b/chroma-agent/iml-storage-server.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=IML Storage Server Service Target
+Before=chroma-agent.service
+Wants=device-scanner.target

--- a/chroma-manager/agent-bootstrap-script.template
+++ b/chroma-manager/agent-bootstrap-script.template
@@ -1,9 +1,10 @@
-
 # Set the time, so certs work below ALWAYS.
 # Future NTP job will set it again,
 # so preserving host's date is unecessary
+
 import subprocess
-ret = subprocess.call("date -s @{server_epoch_seconds} > /dev/null 2>&1", shell=True)
+ret = subprocess.call(
+    "date -s @{server_epoch_seconds} > /dev/null 2>&1", shell=True)
 
 import sys
 import httplib
@@ -25,7 +26,9 @@ bootstrap_log.setLevel(logging.DEBUG)
 
 handler = logging.FileHandler('/var/log/chroma-agent.log')
 handler.setLevel(logging.DEBUG)
-handler.setFormatter(logging.Formatter('[%(asctime)s] bootstrap %(name)s %(levelname)s %(message)s'))
+handler.setFormatter(
+    logging.Formatter(
+        '[%(asctime)s] bootstrap %(name)s %(levelname)s %(message)s'))
 bootstrap_log.addHandler(handler)
 
 SSL_DIR = "/var/lib/chroma/"
@@ -57,13 +60,15 @@ class VerifiedHTTPSConnection(httplib.HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        self.sock = ssl.wrap_socket(sock, cert_reqs=ssl.CERT_REQUIRED, ca_certs=AUTHORITY_CERT)
+        self.sock = ssl.wrap_socket(
+            sock, cert_reqs=ssl.CERT_REQUIRED, ca_certs=AUTHORITY_CERT)
 
 
 class VerifiedHTTPSHandler(urllib2.HTTPSHandler):
-    def __init__(self, connection_class = VerifiedHTTPSConnection):
+    def __init__(self, connection_class=VerifiedHTTPSConnection):
         self.specialized_conn_class = connection_class
         urllib2.HTTPSHandler.__init__(self)
+
     def https_open(self, req):
         return self.do_open(self.specialized_conn_class, req)
 
@@ -98,7 +103,8 @@ def setup_keys():
 def reg_manager():
     fqdn = socket.getfqdn()
     nodename = os.uname()[1]
-    csr = launch_command("openssl req -new -subj /C=/ST=/L=/O=/CN=%s -key %s" % (fqdn, PRIVATE_KEY))
+    csr = launch_command("openssl req -new -subj /C=/ST=/L=/O=/CN=%s -key %s" %
+                         (fqdn, PRIVATE_KEY))
 
     data = json.dumps({{
         'address': socket.gethostbyname(socket.gethostname()),
@@ -107,7 +113,7 @@ def reg_manager():
         'version': 0,
         'csr': csr,
         'capabilities': []
-        }})
+    }})
 
     try:
         https_handler = VerifiedHTTPSHandler()
@@ -127,7 +133,8 @@ def reg_manager():
 
 def create_repo():
     tmp = tempfile.NamedTemporaryFile()
-    tmp.write(REPO_CONTENT.format(repo_url, AUTHORITY_CERT, PRIVATE_KEY, AGENT_CERT))
+    tmp.write(
+        REPO_CONTENT.format(repo_url, AUTHORITY_CERT, PRIVATE_KEY, AGENT_CERT))
 
     tmp.flush()
     launch_command('cp %s %s' % (tmp.name, REPO_PATH))
@@ -135,20 +142,30 @@ def create_repo():
 
 
 def install_agent():
-    return launch_command('yum install -y --enablerepo=%s %s' % ('{repo_names}', repo_packages))
+    return launch_command('yum install -y --enablerepo=%s %s' %
+                          ('{repo_names}', repo_packages))
 
 
 def configure_server():
-    launch_command('chroma-agent set_server_url --url %s' % base_url + 'agent/')
-    launch_command("chroma-agent set_profile --profile_json '%s'" % profile_json)
+    launch_command(
+        'chroma-agent set_server_url --url %s' % base_url + 'agent/')
+    launch_command(
+        "chroma-agent set_profile --profile_json '%s'" % profile_json)
 
 
-def start_agent():
-    output = launch_command("systemctl enable chroma-agent")
-    output = launch_command("systemctl start chroma-agent")
+def start_services():
+    launch_command("systemctl enable chroma-agent.service")
+    launch_command("systemctl start iml-storage-server.target")
 
 
 def kill_zombies():
+    try:
+        # attempt to stop a pre-installed instance
+        launch_command("systemctl stop iml-storage-server.target")
+    except Exception:
+        # Will fail if not pre-installed
+        pass
+
     # ensure that there are no old agents hanging around
     for pid in [d for d in os.listdir('/proc') if d.isdigit()]:
         try:
@@ -158,6 +175,7 @@ def kill_zombies():
         except (OSError, IOError):
             # Don't bail if this fails -- it's not critical
             pass
+
 
 def main():
     try:
@@ -181,16 +199,20 @@ def main():
 
         bootstrap_log.info('Agent bootstrap completed, starting agent...')
 
-        # Finally start the agent, it will take it from here.
-        start_agent()
+        # Finally start the services.
+        start_services()
 
-        print json.dumps({{'host_id': registration_response['host_id'], 'command_id': registration_response['command_id']}})
+        print json.dumps({{
+            'host_id': registration_response['host_id'],
+            'command_id': registration_response['command_id']
+        }})
 
         return 0
 
     except Exception, err:
         bootstrap_log.exception('Error from agent-bootstrap-script main():')
         return 1
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/chroma-manager/scripts/deploy_build
+++ b/chroma-manager/scripts/deploy_build
@@ -119,7 +119,7 @@ scrub_manager()
 scrub_servers()
 {
     server_list=$(h2hl $SERVERS)
-    remote_shell $server_list systemctl stop chroma-agent.service
+    remote_shell $server_list systemctl stop iml-storage-server.target
     remote_shell $server_list yum clean all --enablerepo=*
     remote_shell $server_list yum erase -y chroma* fence-agents*
     remote_shell $server_list rm -f /var/log/chroma* /var/lib/chroma/*

--- a/chroma-manager/tests/framework/integration/existing_filesystem_configuration/cluster_setup
+++ b/chroma-manager/tests/framework/integration/existing_filesystem_configuration/cluster_setup
@@ -139,10 +139,13 @@ fi"
 
 # Install and setup chroma software storage appliances
 pdsh -l root -R ssh -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]}) "exec 2>&1; set -xe
-# if this node uses the Intel proxies, make sure the agent is doing so
+# if this node uses the Intel proxies, make sure the agent and scanner-proxy are doing so
 if [ -f /etc/profile.d/intel_proxy.sh ]; then
     mkdir -p /etc/systemd/system/chroma-agent.service.d/
     echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/chroma-agent.service.d/override.conf
+
+    mkdir -p /etc/systemd/system/scanner-proxy.service.d/
+    echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/scanner-proxy.service.d/override.conf
 fi
 
 # add any repos required by this test run

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -122,10 +122,14 @@ fi
 
 # Install and setup chroma software storage appliances
 pdsh -l root -R ssh -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]}) "exec 2>&1; set -xe
-# if this node uses the Intel proxies, make sure the agent is doing so
+# if this node uses the Intel proxies, make sure the agent and scanner-proxy are doing so
 if [ -f /etc/profile.d/intel_proxy.sh ]; then
     mkdir -p /etc/systemd/system/chroma-agent.service.d/
     echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/chroma-agent.service.d/override.conf
+
+    mkdir -p /etc/systemd/system/scanner-proxy.service.d/
+    echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/scanner-proxy.service.d/override.conf
+
     # IEEL prior to 3.0.0.0 can't set proxies in the chroma-agent environment
     # so we have to hack that into the repos for (real) RHEL
     if [ ${IEEL_FROM_VER//./} -lt 3000 -a -f /etc/yum.repos.d/redhat.repo ]; then

--- a/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
+++ b/chroma-manager/tests/framework/integration/shared_storage_configuration/full_cluster/cluster_setup
@@ -104,10 +104,13 @@ fi"
 # Install and setup chroma software storage appliances
 # shellcheck disable=SC2153
 pdsh -l root -R ssh -S -w $(spacelist_to_commalist ${STORAGE_APPLIANCES[@]} ${WORKERS[@]}) "exec 2>&1; set -xe
-# if this node uses the Intel proxies, make sure the agent is doing so
+# if this node uses the Intel proxies, make sure the agent and scanner-proxy are doing so
 if [ -f /etc/profile.d/intel_proxy.sh ]; then
     mkdir -p /etc/systemd/system/chroma-agent.service.d/
     echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/chroma-agent.service.d/override.conf
+
+    mkdir -p /etc/systemd/system/scanner-proxy.service.d/
+    echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/scanner-proxy.service.d/override.conf
 fi
 
 # add any repos required by this test run

--- a/scripts/deploy_build
+++ b/scripts/deploy_build
@@ -30,10 +30,13 @@ CHROMA_PASS="lustre"
 CHROMA_NTP_SERVER="localhost"
 pdsh -R ssh -l root -S -w "$ALL_NODES" "set -ex
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-# if this node uses the Intel proxies, make sure the agent is doing so
+# if this node uses the Intel proxies, make sure the agent and scanner-proxy are doing so
 if [ -f /etc/profile.d/intel_proxy.sh ]; then
     mkdir -p /etc/systemd/system/chroma-agent.service.d/
     echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/chroma-agent.service.d/override.conf
+
+    mkdir -p /etc/systemd/system/scanner-proxy.service.d/
+    echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/scanner-proxy.service.d/override.conf
 fi
 
 yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/repo/epel-7/managerforlustre-manager-for-lustre-epel-7.repo
@@ -84,10 +87,13 @@ echo \"Installation complete.  Manager can be reached at https://\$(ip addr ls d
 "
 
 pdsh -R ssh -l root -S -w "$STORAGE_NODES" "set -ex
-# if this node uses the Intel proxies, make sure the agent is doing so
+# if this node uses the Intel proxies, make sure the agent and scanner-proxy are doing so
 if [ -f /etc/profile.d/intel_proxy.sh ]; then
     mkdir -p /etc/systemd/system/chroma-agent.service.d/
     echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/chroma-agent.service.d/override.conf
+
+    mkdir -p /etc/systemd/system/scanner-proxy.service.d/
+    echo -e \"[Service]\\nEnvironmentFile=-/etc/profile.d/intel_proxy.sh\" > /etc/systemd/system/scanner-proxy.service.d/override.conf
 fi" | dshbak -c
 if [ ${PIPESTATUS[0]} != 0 ]; then
     exit 1


### PR DESCRIPTION
Fixes #572

Now that we are creating smaller stand-alone services, we need the ability to start / stop them in tandem.

We can create either a iml-storage-server.target or dummy iml-storage-server.service unit to control starting / stopping these services in tandem.

This will handle the following services (so far) either directly or indirectly:

chroma-agent
device-scanner
scanner-proxy
mount-emitter
Things we need to consider:

We should repopulate the scanner if the service has stopped, but not if it has been running since boot.

Signed-off-by: Joe Grund <joe.grund@intel.com>