### PR TITLE
Fail fast on plugin load error

### DIFF
--- a/chroma-agent/chroma_agent/plugin_manager.py
+++ b/chroma-agent/chroma_agent/plugin_manager.py
@@ -77,6 +77,7 @@ class PluginManager(object):
             except Exception:
                 daemon_log.warn("** error loading plugin %s" % name)
                 daemon_log.warn(traceback.format_exc())
+                raise
 
     @classmethod
     def _find_plugins(cls):


### PR DESCRIPTION
The agent currently logs any exceptions during plugin load and chugs
forward. When this occurs, plugins are dropped, leading to difficult
to debug errors later on when that plugin is invoked.

Instead, we should be explicit and fail fast on a plugin import error.
Systemd will restart the unit after fail to give loading another shot.

Signed-off-by: Joe Grund <joe.grund@intel.com>