### PR TITLE
Remove caching of localMounts

### DIFF
--- a/chroma-agent/chroma_agent/device_plugins/block_devices.py
+++ b/chroma-agent/chroma_agent/device_plugins/block_devices.py
@@ -301,16 +301,25 @@ def parse_sys_block(device_map):
 
 
 def get_normalized_device_table():
-    """ process block device info returned by device-scanner to produce a ndt """
+    """ process block device info returned by
+        device-scanner to produce a ndt
+    """
     return parse_sys_block(scanner_cmd("Stream"))
 
 
-def get_local_mounts():
-    """ process block device info returned by device-scanner to produce a ndt """
+def parse_local_mounts(xs):
+    """ process block device info returned by device-scanner to produce
+        a legacy version of local mounts
+    """
     return [
         (d['source'], d['target'], d['fstype'])
-        for d in scanner_cmd("Stream")['localMounts']
+        for d in xs
     ]
+
+
+def get_local_mounts():
+    xs = scanner_cmd("Stream")['localMounts']
+    return parse_local_mounts(xs)
 
 
 def paths_to_major_minors(node_block_devices, ndt, device_paths):

--- a/chroma-agent/chroma_agent/device_plugins/block_devices.py
+++ b/chroma-agent/chroma_agent/device_plugins/block_devices.py
@@ -305,9 +305,12 @@ def get_normalized_device_table():
     return parse_sys_block(scanner_cmd("Stream"))
 
 
-def get_local_mounts(data_source=scanner_cmd("Stream")['localMounts']):
+def get_local_mounts():
     """ process block device info returned by device-scanner to produce a ndt """
-    return [(d['source'], d['target'], d['fstype']) for d in data_source]
+    return [
+        (d['source'], d['target'], d['fstype'])
+        for d in scanner_cmd("Stream")['localMounts']
+    ]
 
 
 def paths_to_major_minors(node_block_devices, ndt, device_paths):

--- a/chroma-agent/chroma_agent/device_plugins/lustre.py
+++ b/chroma-agent/chroma_agent/device_plugins/lustre.py
@@ -16,7 +16,7 @@ from chroma_agent.plugin_manager import DevicePlugin
 from chroma_agent import plugin_manager
 from chroma_agent.device_plugins.linux import LinuxDevicePlugin
 from iml_common.lib.exception_sandbox import exceptionSandBox
-from chroma_agent.device_plugins.block_devices import get_normalized_device_table, get_local_mounts, scanner_cmd
+from chroma_agent.device_plugins.block_devices import get_normalized_device_table, get_local_mounts
 from chroma_agent.lib.yum_utils import yum_util
 from iml_common.lib.date_time import IMLDateTime
 
@@ -152,8 +152,7 @@ class LustrePlugin(DevicePlugin):
     def _scan_mounts(self):
         mounts = {}
 
-        data = scanner_cmd("Stream")
-        local_mounts = get_local_mounts(data['localMounts'])
+        local_mounts = get_local_mounts()
         zfs_mounts = [(d, m, f) for d, m, f in local_mounts if f == 'zfs']
 
         for device, mntpnt, fstype in local_mounts:

--- a/chroma-agent/chroma_agent/device_plugins/lustre.py
+++ b/chroma-agent/chroma_agent/device_plugins/lustre.py
@@ -16,7 +16,7 @@ from chroma_agent.plugin_manager import DevicePlugin
 from chroma_agent import plugin_manager
 from chroma_agent.device_plugins.linux import LinuxDevicePlugin
 from iml_common.lib.exception_sandbox import exceptionSandBox
-from chroma_agent.device_plugins.block_devices import get_normalized_device_table, get_local_mounts
+from chroma_agent.device_plugins.block_devices import get_normalized_device_table, parse_local_mounts, scanner_cmd
 from chroma_agent.lib.yum_utils import yum_util
 from iml_common.lib.date_time import IMLDateTime
 
@@ -152,7 +152,8 @@ class LustrePlugin(DevicePlugin):
     def _scan_mounts(self):
         mounts = {}
 
-        local_mounts = get_local_mounts()
+        data = scanner_cmd("Stream")
+        local_mounts = parse_local_mounts(data['localMounts'])
         zfs_mounts = [(d, m, f) for d, m, f in local_mounts if f == 'zfs']
 
         for device, mntpnt, fstype in local_mounts:


### PR DESCRIPTION
localMounts are currently being cached at module load time, and are
never evaluated afterwards.

This is causing us a bunch of issues where mount state is not as
expected.

Remove the caching, so we evaulate local mounts each time we call the
function.

Signed-off-by: Joe Grund <joe.grund@intel.com>