### PR TITLE
Use journal for agent logging.

### DIFF
--- a/chroma-agent/chroma_agent/cli.py
+++ b/chroma-agent/chroma_agent/cli.py
@@ -17,10 +17,11 @@ from chroma_agent.plugin_manager import ActionPluginManager
 def configure_logging():
     import logging
     from chroma_agent.log import console_log, daemon_log
+    from systemd.journal import JournalHandler
 
-    console_log.addHandler(logging.StreamHandler(sys.stderr))
+    console_log.addHandler(JournalHandler(SYSLOG_IDENTIFIER='iml-agent-console'))
     console_log.setLevel(logging.INFO)
-    daemon_log.addHandler(logging.StreamHandler(sys.stderr))
+    daemon_log.addHandler(JournalHandler(SYSLOG_IDENTIFIER='iml-agent-daemon'))
     daemon_log.setLevel(logging.WARNING)
 
 

--- a/chroma-agent/chroma_agent/log.py
+++ b/chroma-agent/chroma_agent/log.py
@@ -6,8 +6,6 @@ import logging
 import os
 import sys
 
-from systemd.journal import JournalHandler
-
 # This log is for messages about the internal machinations of our
 # daemon and messaging systems, the user would only be interested
 # in warnings and errors
@@ -62,16 +60,19 @@ def decrease_loglevel(signal, frame):
 # Not setting up logs at import time because we want to
 # set them up after daemonization
 def daemon_log_setup():
+    from systemd.journal import JournalHandler
     daemon_log.addHandler(JournalHandler(SYSLOG_IDENTIFIER='iml-agent-daemon'))
 
 
 def console_log_setup():
+    from systemd.journal import JournalHandler
     console_log.addHandler(
         JournalHandler(SYSLOG_IDENTIFIER='iml-agent-console'))
 
 
 # Log copytool stuff to syslog because we may have multiple processes running.
 def copytool_log_setup():
+    from systemd.journal import JournalHandler
     copytool_log.addHandler(
         JournalHandler(SYSLOG_IDENTIFIER='iml-agent-copytool'))
 


### PR DESCRIPTION
We can unify logging a bit (timestamps included) by using
the journal for logging instead of separate log files for agent
components.

Signed-off-by: Joe Grund <joe.grund@intel.com>