### PR TITLE
Efs install parallel2

### DIFF
--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -139,7 +139,10 @@ class CreateLustreFilesystem(UtilityTestCase):
         # for the moment efs tests are not run with mixed device types
         # therefore install on all hosts straightaway
         def get_hosts(target):
-            return [target['primary_server']] + [target['secondary_server']] if 'secondary_server' in target else []
+            host_list = [target['primary_server']]
+            if 'secondary_server' in target:
+                host_list.append(target['secondary_server'])
+            return host_list
 
         hosts = get_hosts(self.mgt)
         device_type = self.get_lustre_server_by_name(hosts[0])['device_type']

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -285,19 +285,11 @@ class CreateLustreFilesystem(UtilityTestCase):
 
         block_device = TestBlockDevice(device_type, device_path)
 
-        self.execute_simultaneous_commands(
-            block_device.install_packages_commands, targets.values(),
-            'install blockdevice packages')
-
-        self.execute_commands(block_device.prepare_device_commands,
-                              targets['primary_server'], 'prepare device')
+        self.execute_commands(block_device.reset_device_commands,
+                              targets['primary_server'], 'reset device')
 
         filesystem = TestFileSystem(block_device.preferred_fstype,
                                     block_device.device_path)
-
-        self.execute_simultaneous_commands(
-            filesystem.install_packages_commands, targets.values(),
-            'install filesystem packages')
 
         result = self.remote_command(targets['primary_server'],
                                      filesystem.mkfs_command(

--- a/chroma-manager/tests/integration/utils/test_filesystems/test_filesystem.py
+++ b/chroma-manager/tests/integration/utils/test_filesystems/test_filesystem.py
@@ -58,7 +58,3 @@ class TestFileSystem(object):
     @abc.abstractproperty
     def mount_path(self):
         pass
-
-    @property
-    def install_packages_commands(cls):
-        return []


### PR DESCRIPTION
Install packages in parallel during EFS tests, this can be done when creating the lustre file system and before running tests due to the assumption that all device types for targets are the same in a test.

Changes can be easily reverted if we need to have a mix of device types for EFS testing in the future.

Fixes #591 
Duplicates #591 