### PR TITLE
Fix LNet Detection

### DIFF
--- a/chroma-agent/chroma_agent/device_plugins/linux_network.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_network.py
@@ -318,13 +318,8 @@ class LinuxNetworkDevicePlugin(DevicePlugin):
         Uses /proc/module and /proc/sys/lnet/stats to decide is lnet is up, down or unloaded
         :return: lnet_up, lnet_down or lnet_unloaded
         '''
-        lnet_loaded = False
-        for module_line in open("/proc/modules").readlines():
-            if module_line.startswith("lnet "):
-                lnet_loaded = True
-                break
-
-        lnet_up = os.path.exists("/proc/sys/lnet/stats")
+        lnet_loaded = not bool(AgentShell.run(['udevadm', 'info', '--path', '/sys/module/lnet']).rc)
+        lnet_up = not bool(AgentShell.run(['lnetctl', 'net', 'show']).rc)
 
         return {(False, False): "lnet_unloaded",
                  (False, True): "lnet_unloaded",

--- a/chroma-agent/chroma_agent/device_plugins/linux_network.py
+++ b/chroma-agent/chroma_agent/device_plugins/linux_network.py
@@ -314,12 +314,11 @@ class LinuxNetworkDevicePlugin(DevicePlugin):
         cls.cached_results = raw_result
 
     def _lnet_state(self):
-        '''
-        Uses /proc/module and /proc/sys/lnet/stats to decide is lnet is up, down or unloaded
-        :return: lnet_up, lnet_down or lnet_unloaded
-        '''
+        lnet_up = False
         lnet_loaded = not bool(AgentShell.run(['udevadm', 'info', '--path', '/sys/module/lnet']).rc)
-        lnet_up = not bool(AgentShell.run(['lnetctl', 'net', 'show']).rc)
+        
+        if lnet_loaded:
+            lnet_up = not bool(AgentShell.run(['lnetctl', 'net', 'show']).rc)
 
         return {(False, False): "lnet_unloaded",
                  (False, True): "lnet_unloaded",


### PR DESCRIPTION
We are currently determining if LNet is loaded by looking for "lnet"
inside of "/proc/modules." Furthermore, we are checking to see if lnet
is up by looking at "/proc/sys/lnet/stats". This is a problem for a
couple of reasons:
1. We shouldn't have to rely on looking at these files
2. What if the files change (and they are in an upcoming version of
Lustre).

A better solution is to:
1. use the result of "udevadm info --path /sys/module/lnet" to determine if lnet is loaded
2. Use the result of "lnetctl net show" to determine if lnet is started

By doing this, we are using reliable commands and are no longer coupled
to these files.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>