### PR TITLE
Separate prepare_device_commands into wipe_signatures and create_device

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -929,9 +929,9 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                     'zfs',
                     server0['orig_device_paths'][lustre_device['path_index']])
 
-                self.execute_commands(zfs_device.prepare_device_commands,
+                self.execute_commands(zfs_device.reset_device_commands,
                                       server0['fqdn'],
-                                      'create zfs device %s' % zfs_device)
+                                      'reset zfs device %s' % zfs_device)
 
                 partprobe_devices.append(
                     server0['orig_device_paths'][lustre_device['path_index']])
@@ -981,7 +981,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         ]
 
         def wipe(x):
-            return 'wipefs -a {0} && parted {0} mklabel gpt'.format(x)
+            return 'wipefs -a {0}'.format(x)
 
         self.execute_commands([wipe(x) for x in zfs_device_paths],
                               server0['fqdn'], 'wiping disks')

--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -981,7 +981,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         ]
 
         def wipe(x):
-            return 'wipefs -a {0}'.format(x)
+            return 'wipefs -a {0} && parted {0} mklabel gpt'.format(x)
 
         self.execute_commands([wipe(x) for x in zfs_device_paths],
                               server0['fqdn'], 'wiping disks')

--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -981,7 +981,7 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         ]
 
         def wipe(x):
-            return 'wipefs -a {0} && parted {0} mklabel gpt'.format(x)
+            return 'wipefs -a {0}'.format(x)
 
         self.execute_commands([wipe(x) for x in zfs_device_paths],
                               server0['fqdn'], 'wiping disks')

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -225,7 +225,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         for device in lustre_server['device_paths']:
             self.remote_command(
                 server_name,
-                "wipefs -a {0}".format(device))
+                "wipefs -a {0} && parted {0} mklabel gpt".format(device))
 
     def rename_device(self, device_old_path, device_new_path):
         for lustre_server in config['lustre_servers']:

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -225,7 +225,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         for device in lustre_server['device_paths']:
             self.remote_command(
                 server_name,
-                "wipefs -a {0} && parted {0} mklabel gpt".format(device))
+                "wipefs -a {0}".format(device))
 
     def rename_device(self, device_old_path, device_new_path):
         for lustre_server in config['lustre_servers']:

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -225,7 +225,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         for device in lustre_server['device_paths']:
             self.remote_command(
                 server_name,
-                "wipefs -a {0} && parted {0} mklabel gpt".format(device))
+                "wipefs -a {0}".format(device))
 
     def rename_device(self, device_old_path, device_new_path):
         for lustre_server in config['lustre_servers']:
@@ -285,8 +285,8 @@ class CreateLustreFilesystem(UtilityTestCase):
 
         block_device = TestBlockDevice(device_type, device_path)
 
-        self.execute_commands(block_device.prepare_device_commands,
-                              targets['primary_server'], 'prepare device')
+        self.execute_commands(block_device.reset_device_commands,
+                              targets['primary_server'], 'reset device')
 
         filesystem = TestFileSystem(block_device.preferred_fstype,
                                     block_device.device_path)

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice.py
@@ -51,8 +51,16 @@ class TestBlockDevice(object):
         return []
 
     @property
-    def prepare_device_commands(self):
+    def wipe_device_commands(self):
+        return ['wipefs -a {}'.format(self._device_path)]
+
+    @property
+    def create_device_commands(self):
         return []
+
+    @property
+    def reset_device_commands(self):
+        return self.wipe_device_commands + self.create_device_commands
 
     @classmethod
     def all_clear_device_commands(cls, device_paths):

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
@@ -21,6 +21,10 @@ class TestBlockDeviceLinux(TestBlockDevice):
         return self._device_path
 
     @property
+    def wipe_device_commands(self):
+        return ['wipefs -a {}'.format(self.device_path)]
+
+    @property
     def destroy_commands(self):
         return ['wipefs -a {}'.format(self.device_path)]
 

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
@@ -19,11 +19,10 @@ class TestBlockDeviceLvm(TestBlockDevice):
 
     # Create a lvm on the device.
     @property
-    def prepare_device_commands(self):
+    def create_device_commands(self):
         # FIXME: the use of --yes in the {vg,lv}create commands is a work-around for #500
         # and should be reverted when #500 is fixed
         return [
-            "wipefs -a %s" % self._device_path,
             "vgcreate --yes %s %s; lvcreate --yes --wipesignatures n -l 100%%FREE --name %s %s"
             % (self.vg_name, self._device_path, self.lv_name, self.vg_name)
         ]

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
@@ -23,10 +23,9 @@ class TestBlockDeviceLvm(TestBlockDevice):
         # FIXME: the use of --yes in the {vg,lv}create commands is a work-around for #500
         # and should be reverted when #500 is fixed
         return [
-            "wipefs -a {}".format(self._device_path),
-            "vgcreate --yes {0} {1} && lvcreate --yes --wipesignatures n -l 100%%FREE --name {2} {0}".format(
-                self.vg_name, self._device_path, self.lv_name
-            )
+            "wipefs -a %s" % self._device_path,
+            "vgcreate --yes %s %s; lvcreate --yes --wipesignatures n -l 100%%FREE --name %s %s"
+            % (self.vg_name, self._device_path, self.lv_name, self.vg_name)
         ]
 
     @property

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_lvm.py
@@ -24,8 +24,9 @@ class TestBlockDeviceLvm(TestBlockDevice):
         # and should be reverted when #500 is fixed
         return [
             "wipefs -a {}".format(self._device_path),
-            "vgcreate --yes %s %s; lvcreate --yes --wipesignatures n -l 100%%FREE --name %s %s"
-            % (self.vg_name, self._device_path, self.lv_name, self.vg_name)
+            "vgcreate --yes {0} {1} && lvcreate --yes --wipesignatures n -l 100%%FREE --name {2} {0}".format(
+                self.vg_name, self._device_path, self.lv_name
+            )
         ]
 
     @property

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -27,6 +27,7 @@ class TestBlockDeviceZfs(TestBlockDevice):
     @property
     def prepare_device_commands(self):
         return [
+            "parted -s %s mklabel gpt" % self._device_path,
             "zpool create %s -o cachefile=none -o multihost=on %s" %
             (self.device_path, self._device_path)
         ]

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -25,8 +25,9 @@ class TestBlockDeviceZfs(TestBlockDevice):
 
     # Autoimport will not occur if cachefile is none
     @property
-    def prepare_device_commands(self):
+    def create_device_commands(self):
         return [
+            'parted {0} mklabel gpt'.format(self._device_path),
             "zpool create %s -o cachefile=none -o multihost=on %s" %
             (self.device_path, self._device_path)
         ]

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -27,7 +27,6 @@ class TestBlockDeviceZfs(TestBlockDevice):
     @property
     def prepare_device_commands(self):
         return [
-            "parted -s %s mklabel gpt" % self._device_path,
             "zpool create %s -o cachefile=none -o multihost=on %s" %
             (self.device_path, self._device_path)
         ]


### PR DESCRIPTION
EFS tests are failing because during test reset we wipe disks and then create a gpt partition, subsequently vgcreate cannot operate on the base disk (because it now has a partition).

Initially create gpt partition before creating zpool but not after wiping disks to avoid the above.

Separate out actions for preparing a device into wiping the signatures and actually creating the device, create a new commands method to reset device calling both wipe and create.

Fixes #587 