### PR TITLE
Disable and stop all iml-storage-server.target services on remove

### DIFF
--- a/chroma-agent/chroma_agent/action_plugins/agent_setup.py
+++ b/chroma-agent/chroma_agent/action_plugins/agent_setup.py
@@ -29,40 +29,26 @@ def _service_is_running():
     return agent_service.running
 
 
-def _start_service():
-    return agent_ok_or_error(agent_service.start())
-
-
-def _stop_service():
-    return agent_ok_or_error(agent_service.stop())
-
-
-def _service_is_enabled():
-    return agent_service.enabled
-
-
-def _enable_service():
-    return agent_ok_or_error(agent_service.enable())
-
-
-def _disable_service():
-    return agent_ok_or_error(agent_service.disable())
-
-
 def deregister_server():
     config.delete('settings', 'server')
 
     def disable_and_kill():
-        console_log.info("Disabling chroma-agent service")
-        _disable_service()
+        console_log.info("Disabling iml-storage-server units")
+
+        map(lambda x: ServiceControl.create(x).disable(), [
+            'device-scanner.socket',
+            'mount-emitter.service',
+            'swap-emitter.service',
+            'scanner-proxy.path'
+        ])
 
         console_log.info("Terminating")
-        os._exit(0)
+        ServiceControl.create('iml-storage-server.target').stop()
 
     raise CallbackAfterResponse(None, disable_and_kill)
 
 
-def register_server(url, ca, secret, address =None):
+def register_server(url, ca, secret, address=None):
     if _service_is_running() is True:
         console_log.warning("chroma-agent service was running before registration, stopping.")
         agent_service.stop()


### PR DESCRIPTION
We only disable / stop the agent on host removal.
Instead, we should disable / stop all relevant
storage server units.

Signed-off-by: Joe Grund <joe.grund@intel.com>