### PR TITLE
Replace use of fstab in EFS with systemd mount units

### DIFF
--- a/chroma-manager/tests/integration/core/utility_testcase.py
+++ b/chroma-manager/tests/integration/core/utility_testcase.py
@@ -279,9 +279,9 @@ class UtilityTestCase(TestCase):
             server,
             "systemctl daemon-reload")
 
-#        self.remote_command(
-#            server,
-#            "systemctl enable {}".format(name))
+        self.remote_command(
+            server,
+            "systemctl enable {}".format(name))
 
         self.remote_command(
             server,

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -241,15 +241,15 @@ class CreateLustreFilesystem(UtilityTestCase):
         # When this routine is called the target must be accessible from the primary_target
         if (target.get('failover_mode') == 'failnode') and (
                 target.get('mount_server') == 'secondary_server'):
-            self.remote_command(target['primary_server'],
-                                'systemctl daemon-reload')
-            self.remote_command(target['primary_server'],
-                                'mkdir -p %s' % target['mount_path'])
-            self.remote_command(target['primary_server'],
-                                'mount -t lustre %s %s' %
-                                (device, target['mount_path']))
-            self.remote_command(target['primary_server'],
-                                'umount %s' % target['mount_path'])
+            self.start_mount(
+                target['primary_server'],
+                source=device,
+                target=target['mount_path'],
+                opts='defaults,_netdev')
+
+            self.stop_mount(
+                target['primary_server'],
+                target=target['mount_path'])
 
         target_server = target[target.get('mount_server', 'primary_server')]
 
@@ -262,14 +262,12 @@ class CreateLustreFilesystem(UtilityTestCase):
             self.execute_commands(block_device.capture_commands,
                                   target['secondary_server'], 'Capture device')
 
-        self.remote_command(target_server,
-                            'mkdir -p %s' % target['mount_path'])
-        self.remote_command(target_server, 'mount -t lustre %s %s' %
-                            (device, target['mount_path']))
-        self.remote_command(
+        self.start_mount(
             target_server,
-            "echo '%s   %s  lustre  defaults,_netdev    0 0' >> /etc/fstab" %
-            (device, target['mount_path']))
+            source=device,
+            target=target['mount_path'],
+            opts='defaults,_netdev'
+        )
 
     def configure_target_device(self, target, target_type, fsname, mgs_nids,
                                 mkfs_options):

--- a/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
+++ b/chroma-manager/tests/integration/existing_filesystem_configuration/utils/create_lustre_filesystem.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from testconfig import config
-from tests.integration.core.utility_testcase import UtilityTestCase
+from tests.integration.core.utility_testcase import UtilityTestCase, stop_mount_commands
 from tests.integration.utils.test_blockdevices.test_blockdevice import TestBlockDevice
 from tests.integration.utils.test_filesystems.test_filesystem import TestFileSystem
 
@@ -100,7 +100,7 @@ class CreateLustreFilesystem(UtilityTestCase):
         self.execute_simultaneous_commands(
             reduce(
                 lambda acc, x: acc + x,
-                [self.stop_mount_commands(m) for m in mounts],
+                [stop_mount_commands(m) for m in mounts],
                 []),
             [s['address'] for s in config['lustre_servers']],
             'stop all lustre systemd mount units',


### PR DESCRIPTION
Use systemd units to mount and umount lustre targets in EFS, primarily to fix an issue during test setup where using fstab to persist mount info a mount command fails when previous lvm mount unit remains in cache.

This solution does mean that `mount -a -t lustre` will not start systemd mount units and mount/umount calls from EFS tests will need to be replaced with explicitly named `systemctl` start/stop commands for the desired mount unit.

Mount unit filenames can be derived from cluster configuration files but in order for this approach to work a teardown routine will need to be added to EFS.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>
