### PR TITLE
Fixup device cleaning

### DIFF
--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice.py
@@ -52,7 +52,10 @@ class TestBlockDevice(object):
 
     @property
     def wipe_device_commands(self):
-        return ['wipefs -a {}'.format(self._device_path)]
+        return [
+            'wipefs -a {}'.format(self._device_path),
+            'udevadm settle'
+        ]
 
     @property
     def create_device_commands(self):

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_linux.py
@@ -22,11 +22,14 @@ class TestBlockDeviceLinux(TestBlockDevice):
 
     @property
     def wipe_device_commands(self):
-        return ['wipefs -a {}'.format(self.device_path)]
+        return [
+            'wipefs -a {}'.format(self.device_path),
+            'udevadm settle'
+        ]
 
     @property
     def destroy_commands(self):
-        return ['wipefs -a {}'.format(self.device_path)]
+        return self.wipe_device_commands
 
     def __str__(self):
         return '%s' % self.device_path

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -28,7 +28,8 @@ class TestBlockDeviceZfs(TestBlockDevice):
     def create_device_commands(self):
         return [
             'parted {0} mklabel gpt'.format(self._device_path),
-            "zpool create %s -o cachefile=none -o multihost=on %s" %
+            'udevadm settle',
+            'zpool create %s -o cachefile=none -o multihost=on %s' %
             (self.device_path, self._device_path)
         ]
 


### PR DESCRIPTION
There appears to have been a recent regression, where
we are no longer waiting for udev to settle after
wiping disks and creating partitions.

Add udevadm settle back to relevant areas.

Signed-off-by: Joe Grund <joe.grund@intel.com>