### PR TITLE
Fix zpool labelclear

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -929,9 +929,9 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
                     'zfs',
                     server0['orig_device_paths'][lustre_device['path_index']])
 
-                self.execute_commands(zfs_device.reset_device_commands,
+                self.execute_commands(zfs_device.create_device_commands,
                                       server0['fqdn'],
-                                      'reset zfs device %s' % zfs_device)
+                                      'create zfs device %s' % zfs_device)
 
                 partprobe_devices.append(
                     server0['orig_device_paths'][lustre_device['path_index']])
@@ -970,14 +970,12 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
             if x['backend_filesystem'] == 'zfs'
         ]
 
-        zfs_devices = [TestBlockDevice('zfs', x) for x in zfs_device_paths]
-
         [
             self.execute_simultaneous_commands(
-                x.clear_device_commands([x.device_path]),
+                TestBlockDevice('zfs', x).clear_device_commands([x]),
                 fqdns,
                 'destroy zpool %s' % x,
-                expected_return_code=None) for x in zfs_devices
+                expected_return_code=None) for x in zfs_device_paths
         ]
 
         def wipe(x):

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -23,14 +23,6 @@ class TestBlockDeviceZfs(TestBlockDevice):
     def preferred_fstype(self):
         return 'zfs'
 
-    @property
-    def wipe_device_commands(self):
-        return [
-            'zpool destroy {}'.format(self.device_path),
-            'zpool labelclear {}-part1'.format(self._device_path),
-            'wipefs -a {}'.format(self._device_path), 'udevadm settle'
-        ]
-
     # Autoimport will not occur if cachefile is none
     @property
     def create_device_commands(self):

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -23,6 +23,14 @@ class TestBlockDeviceZfs(TestBlockDevice):
     def preferred_fstype(self):
         return 'zfs'
 
+    @property
+    def wipe_device_commands(self):
+        return [
+            'zpool destroy {}'.format(self.device_path),
+            'zpool labelclear {}-part1'.format(self._device_path),
+            'wipefs -a {}'.format(self._device_path), 'udevadm settle'
+        ]
+
     # Autoimport will not occur if cachefile is none
     @property
     def create_device_commands(self):


### PR DESCRIPTION
`zpool labelclear` was attempting to use the disk partition. However, it was using the zpool name with a `part1` suffix which meant the label was never cleared.

In addition, clearing the device was happening twice, so for now switch back from reseting the device to creating it.

Signed-off-by: Joe Grund <joe.grund@intel.com>