### PR TITLE
SSI: Verification of metrics fails intermittently

### DIFF
--- a/chroma-manager/tests/integration/core/stats_testcase_mixin.py
+++ b/chroma-manager/tests/integration/core/stats_testcase_mixin.py
@@ -1,5 +1,3 @@
-
-
 import logging
 
 from testconfig import config
@@ -36,8 +34,6 @@ class StatsTestCaseMixin(ChromaIntegrationTestCase):
         'kbytesfree',
         'kbytestotal',
         'num_exports',
-        'stats_connect',
-        'stats_create',
         'stats_read_bytes',
         'stats_read_iops',
         'stats_write_bytes',
@@ -108,9 +104,11 @@ class StatsTestCaseMixin(ChromaIntegrationTestCase):
         fs = self.get_filesystem(filesystem_id)
         self.assertTrue(len(targets_metrics) == len(fs[target_kind.lower() + 's']))
 
-        # logger.debug('Checking target metrics are present, metrics: %s , provided metric names: %s' % (targets_metrics,
-        #                                                                                                metric_names))
-        return all((set(target_metrics.keys()) == set(metric_names)) for target_metrics in targets_metrics)
+        logger.debug(
+            'Checking target metrics are present, metrics: %s , provided metric names: %s'
+            % (targets_metrics, metric_names))
+        return all((set(target_metrics.keys()) == set(metric_names))
+                   for target_metrics in targets_metrics)
 
     def _compare_files(self, address, path1, path2, length_bytes):
         try:
@@ -148,10 +146,14 @@ class StatsTestCaseMixin(ChromaIntegrationTestCase):
             self.remote_operations.mount_filesystem(client, filesystem)
 
         # At start-up, validate expected list of mdt and ost stats are returned from the API before performing checks
-        self.wait_until_true(lambda: self._compare_target_metric_names('MDT', self.mdt_stats, filesystem_id),
-                             'Error in verifying expected MDT metric names being returned from API')
-        self.wait_until_true(lambda: self._compare_target_metric_names('OST', self.ost_stats, filesystem_id),
-                             'Error in verifying expected MDT metric names being returned from API')
+        self.wait_until_true(
+            lambda: self._compare_target_metric_names('MDT', self.mdt_stats, filesystem_id),
+            'Error in verifying expected MDT metric names being returned from API'
+        )
+        self.wait_until_true(
+            lambda: self._compare_target_metric_names('OST', self.ost_stats, filesystem_id),
+            'Error in verifying expected OST metric names being returned from API'
+        )
 
         # Wait for and keep track of client_count
         starting_client_count = 1.0

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
@@ -33,7 +33,10 @@ class TestManagedFilesystemWithFailover(FailoverTestCaseMixin, StatsTestCaseMixi
         self.remote_operations.mount_filesystem(client, filesystem)
         try:
             self.remote_operations.exercise_filesystem(client, filesystem)
-            self.check_stats(filesystem_id)
+            self._fetch_help(lambda: self.check_stats(filesystem_id),
+                             ['tom.nabarro@outlook.com', 'joe.grund@intel.com'],
+                             'Create filesystem failed during check stats',
+                             timeout=9000)
         finally:
             self.remote_operations.unmount_filesystem(client, filesystem)
 

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py
@@ -33,10 +33,7 @@ class TestManagedFilesystemWithFailover(FailoverTestCaseMixin, StatsTestCaseMixi
         self.remote_operations.mount_filesystem(client, filesystem)
         try:
             self.remote_operations.exercise_filesystem(client, filesystem)
-            self._fetch_help(lambda: self.check_stats(filesystem_id),
-                             ['tom.nabarro@outlook.com', 'joe.grund@intel.com'],
-                             'Create filesystem failed during check stats',
-                             timeout=9000)
+            self.check_stats(filesystem_id)
         finally:
             self.remote_operations.unmount_filesystem(client, filesystem)
 


### PR DESCRIPTION
This is a failure within the check_stats routine.

http://jenkins.lotus.hpdd.lab.intel.com/job/integration-tests-shared-storage-configuration/5482/

```
(tests.integration.shared_storage_configuration.test_managed_filesystem_with_failover.TestManagedFilesystemWithFailover) ... FAIL
FAIL
Traceback (most recent call last):
  File "/usr/share/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py", line 72, in test_create_filesystem_with_failover_mds
    filesystem_id, volumes_expected_hosts_in_normal_state = self._test_create_filesystem_with_failover()
  File "/usr/share/chroma-manager/tests/integration/shared_storage_configuration/test_managed_filesystem_with_failover.py", line 36, in _test_create_filesystem_with_failover
    self.check_stats(filesystem_id)
  File "/usr/share/chroma-manager/tests/integration/core/stats_testcase_mixin.py", line 154, in check_stats
    'Error in verifying expected MDT metric names being returned from API')
  File "/usr/share/chroma-manager/tests/integration/core/utility_testcase.py", line 147, in wait_until_true
    'Timed out waiting for %s\nError Message %s' % (inspect.getsource(lambda_expression), error_message))
AssertionError: Timed out waiting for         self.wait_until_true(lambda: self._compare_target_metric_names('OST', self.ost_stats, filesystem_id),
                             'Error in verifying expected MDT metric names being returned from API')

Error Message Error in verifying expected MDT metric names being returned from API
```