### PR TITLE
Exception in plugin_runner log when accessing aggregator socket

### DIFF
--- a/chroma-manager/chroma-manager.conf.template
+++ b/chroma-manager/chroma-manager.conf.template
@@ -224,3 +224,11 @@ server {
         proxy_pass http://unix:/var/run/device-aggregator.sock;
     }
 }
+
+server {
+    listen 127.0.0.1:8008;
+
+    location /device-aggregator {
+        proxy_pass http://unix:/var/run/device-aggregator.sock;
+    }
+}

--- a/chroma-manager/chroma-manager.conf.template
+++ b/chroma-manager/chroma-manager.conf.template
@@ -226,7 +226,7 @@ server {
 }
 
 server {
-    listen 127.0.0.1:8008;
+    listen 127.0.0.1:{{DEVICE_AGGREGATOR_PORT}};
 
     location /device-aggregator {
         proxy_pass http://unix:/var/run/device-aggregator.sock;

--- a/chroma-manager/chroma-manager.spec
+++ b/chroma-manager/chroma-manager.spec
@@ -35,7 +35,6 @@ Requires: python-paramiko
 Requires: python2-kombu >= 3.0.19
 Requires: python-daemon
 Requires: python-requests >= 2.6.0
-Requires: python2-requests-unixsocket
 Requires: python-networkx
 Requires: python2-httpagentparser
 Requires: python-gunicorn

--- a/chroma-manager/chroma_core/management/commands/nginx.py
+++ b/chroma-manager/chroma_core/management/commands/nginx.py
@@ -67,7 +67,8 @@ class Command(BaseCommand):
                 'HTTP_AGENT_PORT': settings.HTTP_AGENT_PORT,
                 'HTTP_API_PORT': settings.HTTP_API_PORT,
                 'REALTIME_PORT': settings.REALTIME_PORT,
-                'VIEW_SERVER_PORT': settings.VIEW_SERVER_PORT
+                'VIEW_SERVER_PORT': settings.VIEW_SERVER_PORT,
+                'DEVICE_AGGREGATOR_PORT': settings.DEVICE_AGGREGATOR_PORT
             }))
             open(conf_path, 'w').write(conf_text)
 

--- a/chroma-manager/chroma_core/plugins/block_devices.py
+++ b/chroma-manager/chroma_core/plugins/block_devices.py
@@ -12,10 +12,9 @@ log.setLevel(DEBUG)
 
 
 def fetch_aggregator():
-    import requests_unixsocket
+    import requests
 
-    session = requests_unixsocket.Session()
-    resp = session.get('http+unix://%2Fvar%2Frun%2Fdevice-aggregator.sock')
+    resp = requests.get('http://127.0.0.1:8008/device-aggregator')
     payload = resp.text
 
     return json.loads(payload)

--- a/chroma-manager/chroma_core/plugins/block_devices.py
+++ b/chroma-manager/chroma_core/plugins/block_devices.py
@@ -5,6 +5,7 @@
 import json
 from logging import DEBUG
 
+import settings
 from chroma_core.services import log_register
 
 log = log_register('plugin_runner')
@@ -14,7 +15,7 @@ log.setLevel(DEBUG)
 def fetch_aggregator():
     import requests
 
-    resp = requests.get('http://127.0.0.1:8008/device-aggregator')
+    resp = requests.get(settings.LOCAL_DEVICE_AGGREGATOR_URL)
     payload = resp.text
 
     return json.loads(payload)

--- a/chroma-manager/scripts/nginx_settings.py
+++ b/chroma-manager/scripts/nginx_settings.py
@@ -39,6 +39,9 @@ _settings = {
     'SSL_PATH': {
         'dev': SITE_ROOT,
         'prod': '/var/lib/chroma'
+    },
+    'DEVICE_AGGREGATOR_PORT': {
+        'all': 8008
     }
 }
 

--- a/chroma-manager/settings.py
+++ b/chroma-manager/settings.py
@@ -289,6 +289,8 @@ DEV_REPO_PATH = os.path.join(os.path.dirname(os.path.abspath(sys.modules['settin
 # address or port, override this
 SERVER_HTTP_URL = "https://%s:%s/" % (socket.getfqdn(), HTTPS_FRONTEND_PORT)
 
+LOCAL_DEVICE_AGGREGATOR_URL = "http://127.0.0.1:{}/device-aggregator".format(DEVICE_AGGREGATOR_PORT)
+
 # Supported power control agents
 SUPPORTED_FENCE_AGENTS = ['fence_apc', 'fence_apc_snmp', 'fence_ipmilan', 'fence_virsh', 'fence_vbox']
 


### PR DESCRIPTION
Exceptions occurring in `plugin_runner.log` due to failing connection attempts to the device aggregator socket:

```
[2018-05-20 20:15:03,293: ERROR/service_thread] Exception in main loop.  backtrace: Traceback (most recent call last):
  File "/usr/share/chroma-manager/chroma_core/services/__init__.py", line 75, in run
    self.service.run()
  File "/usr/share/chroma-manager/chroma_core/services/plugin_runner/agent_daemon.py", line 62, in run
    self._queue.serve(session_callback = self.on_message)
  File "/usr/share/chroma-manager/chroma_core/services/queue.py", line 106, in serve
    return ServiceQueue.serve(self, self.__route_message)
  File "/usr/share/chroma-manager/chroma_core/services/queue.py", line 70, in serve
    callback(message)
  File "/usr/share/chroma-manager/chroma_core/services/queue.py", line 80, in __route_message
    self.__session_callback(message)
  File "/usr/lib/python2.7/site-packages/django/db/transaction.py", line 224, in inner
    return func(*args, **kwargs)
  File "/usr/share/chroma-manager/chroma_core/services/plugin_runner/agent_daemon.py", line 179, in on_message
    HttpAgentRpc().reset_session(fqdn, self._plugin_name, message['session_id'])
  File "/usr/share/chroma-manager/chroma_core/services/rpc.py", line 555, in <lambda>
    return lambda *args, **kwargs: self._call(name, *args, **kwargs)
  File "/usr/share/chroma-manager/chroma_core/services/rpc.py", line 576, in _call
    rpc_client = RpcClientFactory.get_client(self.__class__.__name__)
  File "/usr/share/chroma-manager/chroma_core/services/rpc.py", line 497, in get_client
    raise RuntimeError("Attempted to acquire %s instance after shutdown" % cls.__name__)
RuntimeError: Attempted to acquire RpcClientFactory instance after shutdown
[2018-05-20 20:16:32,732: INFO/scan_daemon] Loaded 2 plugins, 0 sessions
[2018-05-20 20:16:32,746: INFO/queue] Purged 0 messages from 'agent_linux_network_rx' queue
[2018-05-20 20:16:32,762: INFO/queue] Purged 0 messages from 'agent_linux_rx' queue
[2018-05-20 20:16:32,782: INFO/scan_daemon] entering main loop
[2018-05-20 20:18:59,757: INFO/agent_daemon] New session
[2018-05-20 20:18:59,762: INFO/storage_plugin] StorageResourceRecord created 1
[2018-05-20 20:18:59,764: INFO/storage_plugin] Registered plugin instance <linux.Linux object at 0x7fc1681e4910> with id Linux
[2018-05-20 20:18:59,781: INFO/agent_daemon] New session
[2018-05-20 20:18:59,856: INFO/storage_plugin] StorageResourceRecord created 2
[2018-05-20 20:18:59,858: INFO/storage_plugin] Registered plugin instance <linux_network.LinuxNetwork object at 0x7fc16403f490> with id LinuxNetwork
[2018-05-20 20:18:59,916: ERROR/agent_daemon] Exception in agent session for linux from lotus-59vm15.lotus.hpdd.lab.intel.com: Traceback (most recent call last):
  File "/usr/share/chroma-manager/chroma_core/services/plugin_runner/agent_daemon.py", line 168, in on_message
    session.plugin.do_agent_session_start(message['body'])
  File "/usr/share/chroma-manager/chroma_core/lib/storage_plugin/base_plugin.py", line 122, in do_agent_session_start
    self._initial_populate(self.agent_session_start, self._root_resource.host_id, data)
  File "/usr/share/chroma-manager/chroma_core/lib/storage_plugin/base_plugin.py", line 187, in _initial_populate
    fn(*args)
  File "/usr/share/chroma-manager/chroma_core/plugins/linux.py", line 201, in agent_session_start
    devices = get_devices(fqdn)
  File "/usr/share/chroma-manager/chroma_core/plugins/block_devices.py", line 25, in get_devices
    _data = fetch_aggregator()
  File "/usr/share/chroma-manager/chroma_core/plugins/block_devices.py", line 18, in fetch_aggregator
    resp = session.get('http+unix://%2Fvar%2Frun%2Fdevice-aggregator.sock')
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 476, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 464, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', BadStatusLine("''",))
```

As a first step towards debugging this issue, remove dependency on `requests-unixsocket` by creating a local access only endpoint in nginx configuration and access `device-aggregator` over plain http. This means that access attempts are recorded in nginx logs.