### PR TITLE
Account for any non-shared/non-ha volumes available

### DIFF
--- a/chroma-manager/tests/integration/shared_storage_configuration/test_ha_clustering.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_ha_clustering.py
@@ -67,7 +67,9 @@ class TestHaClusterVolumes(ChromaHaTestCase):
 
         cluster_0_host = clusters[0]['peers'][0]
         cluster_1_host = clusters[1]['peers'][0]
-        test_volume = self.get_list("/api/volume/")[0]
+        test_volume = [v for v in self.get_list("/api/volume/")
+                       if len(v['volume_nodes']) > 1 and
+                          v['status'] == "configured-ha"][0]
         payload = {'id': test_volume['id'], 'nodes': []}
         for vn in test_volume['volume_nodes']:
             if str(vn['host_id']) == str(cluster_0_host['id']):

--- a/chroma-manager/tests/integration/shared_storage_configuration/test_volumes.py
+++ b/chroma-manager/tests/integration/shared_storage_configuration/test_volumes.py
@@ -49,8 +49,8 @@ class TestVolumes(ChromaIntegrationTestCase):
     #     self.assertNotIn(ost_volumes[0]['label'], usable_volumes_labels)
 
     def test_volumes_cleared_on_teardown(self):
-        # Create a file system and tear it down, then verify after
-        # tear down that the volumes from the file system no longer
+        # Create a file system and then tear down the manager, then verify
+        # after tear down that the volumes from the file system no longer
         # appear in the database. Repro of HYD-1143.
         host_addresses = [h['address'] for h in config['lustre_servers'][:2]]
         hosts = self.add_hosts(host_addresses)


### PR DESCRIPTION
There could be volumes that are available on a node, depending on how
it was provisioned, that while perfectly valid for a Lustre target,
are not the ha-capable, shared volumes we are interested in.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>