### PR TITLE
SSI: vdev.unknown error during pool creation

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -925,17 +925,13 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         partprobe_devices = []
         for lustre_device in config['lustre_devices']:
             if lustre_device['backend_filesystem'] == 'zfs':
+                zfs_device = TestBlockDevice(
+                    'zfs',
+                    server0['orig_device_paths'][lustre_device['path_index']])
 
-                def create():
-                    path_idx = lustre_device['path_index']
-                    zfs_device = TestBlockDevice(
-                        'zfs', server0['orig_device_paths'][path_idx])
-
-                    self.execute_commands(zfs_device.create_device_commands,
-                                          server0['fqdn'],
-                                          'create zfs device %s' % zfs_device)
-
-                self.wait_for_assert(create, TEST_TIMEOUT)
+                self.execute_commands(zfs_device.create_device_commands,
+                                      server0['fqdn'],
+                                      'create zfs device %s' % zfs_device)
 
                 partprobe_devices.append(
                     server0['orig_device_paths'][lustre_device['path_index']])

--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -925,13 +925,17 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
         partprobe_devices = []
         for lustre_device in config['lustre_devices']:
             if lustre_device['backend_filesystem'] == 'zfs':
-                zfs_device = TestBlockDevice(
-                    'zfs',
-                    server0['orig_device_paths'][lustre_device['path_index']])
 
-                self.execute_commands(zfs_device.create_device_commands,
-                                      server0['fqdn'],
-                                      'create zfs device %s' % zfs_device)
+                def create():
+                    path_idx = lustre_device['path_index']
+                    zfs_device = TestBlockDevice(
+                        'zfs', server0['orig_device_paths'][path_idx])
+
+                    self.execute_commands(zfs_device.create_device_commands,
+                                          server0['fqdn'],
+                                          'create zfs device %s' % zfs_device)
+
+                self.wait_for_assert(create, TEST_TIMEOUT)
 
                 partprobe_devices.append(
                     server0['orig_device_paths'][lustre_device['path_index']])

--- a/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
+++ b/chroma-manager/tests/integration/utils/test_blockdevices/test_blockdevice_zfs.py
@@ -29,7 +29,7 @@ class TestBlockDeviceZfs(TestBlockDevice):
         return [
             'parted {0} mklabel gpt'.format(self._device_path),
             'udevadm settle',
-            'zpool create %s -o cachefile=none -o multihost=on %s' %
+            'i=0; while ! zpool create %s -o cachefile=none -o multihost=on %s && [ $i -lt 10 ]; do sleep 1; let i+=1; done; exit ${PIPESTATUS[0]}' %
             (self.device_path, self._device_path)
         ]
 


### PR DESCRIPTION
Fixes #625

Add a `wait_for_assert` around creating a pool to resolve any races
around partition not being available.

Signed-off-by: Joe Grund <joe.grund@intel.com>