### PR TITLE
3x upgrade needs to upgrade python-iml-agent now

### DIFF
--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -373,6 +373,11 @@ if ${UPGRADE_FROM_3:-false}; then
     yum clean all
 
     yum -y upgrade python2-iml-agent\*
+    echo \"waiting for help on \$HOSTNAME\" | mail -s \"waiting help\" brian.murrell@intel.com
+    touch /tmp/waiting_help
+    while [ -f /tmp/waiting_help ]; do
+        sleep 1
+    done
 
     systemctl stop zed
     rmmod zfs zcommon znvpair spl

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -372,7 +372,7 @@ if ${UPGRADE_FROM_3:-false}; then
     #       our compressed timelines
     yum clean all
 
-    yum -y upgrade chroma-agent\*
+    yum -y upgrade python-iml-agent\*
 
     systemctl stop zed
     rmmod zfs zcommon znvpair spl

--- a/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
+++ b/chroma-manager/tests/framework/integration/installation_and_upgrade/run_tests
@@ -372,7 +372,7 @@ if ${UPGRADE_FROM_3:-false}; then
     #       our compressed timelines
     yum clean all
 
-    yum -y upgrade python-iml-agent\*
+    yum -y upgrade python2-iml-agent\*
 
     systemctl stop zed
     rmmod zfs zcommon znvpair spl


### PR DESCRIPTION
It used to be chroma-agent but since modularization, it's
python-iml-agent.

Run-tests: upgrade-tests
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>