### PR TITLE
Add more service ordering

### DIFF
--- a/chroma-manager/chroma_core/lib/service_config.py
+++ b/chroma-manager/chroma_core/lib/service_config.py
@@ -218,14 +218,6 @@ class ServiceConfig(CommandLine):
             log.error(error)
             raise RuntimeError(error)
 
-        # FIXME: HYD_640: there's really no sane reason to have to set the stderr and
-        #        stdout to None here except that subprocess.PIPE ends up
-        #        blocking subprocess.communicate().
-        #        we need to figure out why
-        # FIXME: this should also be converted to use the common Shell utility class
-        #self.try_shell(["service", "rabbitmq-server", "restart"],
-        #               mystderr=None, mystdout=None)
-        # ServiceControlEL7 really needs a _restart() method
         error = rabbit_service._stop()
         if error:
             log.error(error)

--- a/chroma-manager/iml-manager.target
+++ b/chroma-manager/iml-manager.target
@@ -13,6 +13,9 @@ Requires=iml-syslog.service
 Requires=iml-view-server.service
 Requires=iml-settings-populator.service
 Requires=nginx.service
+Requires=device-aggregator.socket
+After=postgresql.service
+After=rabbitmq-server.service
 After=iml-settings-populator.service
 After=network.target
 


### PR DESCRIPTION
We need to make sure that when starting the
iml-manager.target, we both require the device-aggregator
and wait for postgres + rabbitmq to be up.

Signed-off-by: Joe Grund <joe.grund@intel.com>