### PR TITLE
SSI: fix KeyError in resource_manager due to already removed resource

### DIFF
--- a/chroma-manager/chroma_core/services/plugin_runner/resource_manager.py
+++ b/chroma-manager/chroma_core/services/plugin_runner/resource_manager.py
@@ -1105,10 +1105,13 @@ class ResourceManager(object):
         reported_scoped_resources = []
         reported_global_resources = []
         for r in reported_resources:
-            if isinstance(r._meta.identifier, BaseScopedId):
-                reported_scoped_resources.append(session.local_id_to_global_id[r._handle])
-            else:
-                reported_global_resources.append(session.local_id_to_global_id[r._handle])
+            try:
+                if isinstance(r._meta.identifier, BaseScopedId):
+                    reported_scoped_resources.append(session.local_id_to_global_id[r._handle])
+                else:
+                    reported_global_resources.append(session.local_id_to_global_id[r._handle])
+            except KeyError as e:
+                log.warning('attempting to access resource missing from local-global map {}'.format(e))
 
         # This generator re-runs the query on every loop iteration in order
         # to handle situations where resources returned by the query are


### PR DESCRIPTION
This is a follow-on to https://github.com/intel-hpdd/intel-manager-for-lustre/pull/619 which although increased pass rates, did not entirely fix the issue.

http://jenkins.lotus.hpdd.lab.intel.com/job/integration-tests-shared-storage-configuration/5842/arch=x86_64,distro=el7/artifact/test_logs/sosreport-lotus-46vm3-20180531142427/var/log/chroma/plugin_runner.log/*view*/ 

```
2018-05-31 17:12:40,607: ERROR/agent_daemon] Exception in agent session for linux from lotus-46vm7.lotus.hpdd.lab.intel.com: Traceback (most recent call last):
  File "/usr/share/chroma-manager/chroma_core/services/plugin_runner/agent_daemon.py", line 171, in on_message
    session.plugin.do_agent_session_continue(message['body'])
  File "/usr/share/chroma-manager/chroma_core/lib/storage_plugin/base_plugin.py", line 135, in do_agent_session_continue
    self._update(self.agent_session_continue, self._root_resource.host_id, data)
  File "/usr/share/chroma-manager/chroma_core/lib/storage_plugin/base_plugin.py", line 216, in _update
    self._commit_resource_deletes()
  File "/usr/share/chroma-manager/chroma_core/lib/storage_plugin/base_plugin.py", line 245, in _commit_resource_deletes
    self._delta_delete_global_resources)
  File "/usr/share/chroma-manager/chroma_core/services/dbutils.py", line 68, in wrapper
    result = func(*args, **kwargs)
  File "/usr/share/chroma-manager/chroma_core/services/plugin_runner/resource_manager.py", line 1038, in session_remove_global_resources
    self._cull_lost_resources(session, resources)
  File "/usr/share/chroma-manager/chroma_core/services/dbutils.py", line 68, in wrapper
    result = func(*args, **kwargs)
  File "/usr/share/chroma-manager/chroma_core/services/plugin_runner/resource_manager.py", line 1111, in _cull_lost_resources
    reported_global_resources.append(session.local_id_to_global_id[r._handle])
KeyError: 44
```

Results in the following SSI failure:
```
test_mount_and_unmount (tests.integration.shared_storage_configuration.test_client_mount_management.TestClientMountManagement) ... ERROR
ERROR
Traceback (most recent call last):
  File "/usr/share/chroma-manager/tests/integration/shared_storage_configuration/test_client_mount_management.py", line 18, in setUp
    filesystem_id = self.create_filesystem_standard(self.TEST_SERVERS)
  File "/usr/share/chroma-manager/tests/integration/core/chroma_integration_testcase.py", line 342, in create_filesystem_standard
    'conf_params': {}})
  File "/usr/share/chroma-manager/tests/integration/core/chroma_integration_testcase.py", line 410, in create_filesystem
    timeout=9000)
  File "/usr/share/chroma-manager/tests/integration/core/utility_testcase.py", line 217, in _fetch_help
    return assert_test()
  File "/usr/share/chroma-manager/tests/integration/core/chroma_integration_testcase.py", line 407, in <lambda>
    timeout = LONG_TEST_TIMEOUT),
  File "/usr/share/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py", line 304, in wait_for_command
    command)
AssertionError: {u'jobs': [u'/api/job/53/', u'/api/job/54/', u'/api/job/55/', u'/api/job/56/', u'/api/job/57/', u'/api/job/58/', u'/api/job/59/', u'/api/job/60/', u'/api/job/61/', u'/api/job/62/', u'/api/job/63/', u'/api/job/64/', u'/api/job/65/', u'/api/job/66/', u'/api/job/67/', u'/api/job/68/', u'/api/job/69/'], u'complete': True, u'created_at': u'2018-05-31T18:50:42.782799', u'message': u'Creating filesystem testfs', u'cancelled': True, u'errored': True, u'resource_uri': u'/api/command/17/', u'id': 17, u'logs': u'\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n'}
```
http://jenkins.lotus.hpdd.lab.intel.com/job/integration-tests-shared-storage-configuration/arch=x86_64,distro=el7/5842//consoleFull
