### PR TITLE
Update zfs multihost parameters for test

### DIFF
--- a/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
+++ b/chroma-manager/tests/integration/core/api_testcase_with_test_reset.py
@@ -860,6 +860,15 @@ class ApiTestCaseWithTestReset(UtilityTestCase):
             'checking for zfs presence',
             expected_return_code=None)
 
+        self.execute_simultaneous_commands(
+            [
+                'echo 100 > /sys/module/zfs/parameters/zfs_multihost_history',
+                'echo 20 > /sys/module/zfs/parameters/zfs_multihost_fail_intervals',
+            ],
+            fqdns,
+            'set multihost params for test',
+            expected_return_code=None)
+
         partprobe_devices = []
         for lustre_device in config['lustre_devices']:
             if lustre_device['backend_filesystem'] == 'zfs':


### PR DESCRIPTION
Related to #645, update some multihost parameters
for test to decrease likelyhood of suspension when
MMP writes do not occur over a time interval. Also
log the last 100 MMP writes.

Signed-off-by: Joe Grund <joe.grund@intel.com>